### PR TITLE
Add redirectURI and scopes to NebariApp auth config

### DIFF
--- a/templates/nebariapp.yaml
+++ b/templates/nebariapp.yaml
@@ -20,5 +20,10 @@ spec:
     enabled: {{ .enabled | default true }}
     provider: {{ .provider | default "keycloak" }}
     provisionClient: {{ .provisionClient | default true }}
+    redirectURI: {{ .redirectURI | default "/hub/oauth_callback" }}
+    {{- with .scopes }}
+    scopes:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,6 +21,12 @@ nebariapp:
     enabled: true
     provider: keycloak
     provisionClient: true
+    redirectURI: /hub/oauth_callback  # JupyterHub's OAuth callback
+    scopes:
+      - openid
+      - profile
+      - email
+      - groups
 
 # Shared storage configuration (disabled - requires RWX storage class)
 sharedStorage:


### PR DESCRIPTION
- Add redirectURI: /hub/oauth_callback for JupyterHub OAuth
- Add scopes: openid, profile, email, groups
- Allows JupyterHub to handle OAuth and get user identity