### PR TITLE
Add support for overriding JAppsConfig via Helm values

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nebari-data-science-pack
 description: A Helm chart for deploying JupyterHub with jhub-apps on Kubernetes
 type: application
-version: 0.1.0-alpha.5
+version: 0.1.0-alpha.6
 appVersion: "1.0.0"
 
 dependencies:

--- a/config/jupyterhub/02-jhub-apps.py
+++ b/config/jupyterhub/02-jhub-apps.py
@@ -19,8 +19,16 @@ c.JupyterHub.default_url = "/hub/home"
 c.JupyterHub.template_paths = theme_template_paths
 c.JupyterHub.template_vars = themes.DEFAULT_THEME
 c.JAppsConfig.jupyterhub_config_path = "/usr/local/etc/jupyterhub/jupyterhub_config.py"
-c.JAppsConfig.hub_host = "hub"
-c.JAppsConfig.service_workers = 4
+
+# Apply JAppsConfig overrides from Helm values (jupyterhub.custom.japps-config).
+# Any key in the dict is set as an attribute on c.JAppsConfig, e.g.:
+#   japps-config:
+#     app_title: "My Launcher"
+#     service_workers: 2
+#     allowed_frameworks: ["panel", "streamlit"]
+japps_config = get_config("custom.japps-config", {})
+for key, value in japps_config.items():
+    setattr(c.JAppsConfig, key, value)
 
 # Install jhub-apps (sets up service, roles, etc.)
 c = install_jhub_apps(c, spawner_to_subclass=KubeSpawner)

--- a/values.yaml
+++ b/values.yaml
@@ -44,6 +44,19 @@ jupyterhub:
   # internal OAuth redirects use the real hostname instead of 0.0.0.0.
   custom:
     external-url: ""
+    # jhub-apps (JAppsConfig) overrides.
+    # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
+    # See https://jhub-apps.nebari.dev/docs/configuration for available options.
+    japps-config:
+      hub_host: "hub"
+      service_workers: 4
+      # app_title: "JHub Apps Launcher"
+      # app_icon: ""
+      # conda_envs: []
+      # allowed_frameworks: []
+      # blocked_frameworks: []
+      # additional_services: []
+      # startup_apps: []
   hub:
     # Custom Nebari hub image with jhub-apps pre-installed
     image:


### PR DESCRIPTION
## Summary
- Replace hardcoded `JAppsConfig` settings (`hub_host`, `service_workers`) in `02-jhub-apps.py` with a dynamic override mechanism via `jupyterhub.custom.japps-config`
- Any key in the `japps-config` dict is applied as a `setattr` on `c.JAppsConfig`, matching the pattern used in nebari classic
- Bump chart version to `0.1.0-alpha.6`

## Test plan
- [ ] Deploy chart with default values — verify `hub_host=hub` and `service_workers=4` still apply
- [ ] Override a JAppsConfig field (e.g. `app_title`, `allowed_frameworks`) via values and verify it takes effect