### PR TITLE
feat: add NebariApp landingPage config with healthCheck support

### DIFF
--- a/templates/nebariapp.yaml
+++ b/templates/nebariapp.yaml
@@ -26,4 +26,39 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- end }}
+  {{- with .Values.nebariapp.landingPage }}
+  landingPage:
+    enabled: {{ .enabled | default false }}
+    {{- with .displayName }}
+    displayName: {{ . | quote }}
+    {{- end }}
+    {{- with .description }}
+    description: {{ . | quote }}
+    {{- end }}
+    {{- with .icon }}
+    icon: {{ . | quote }}
+    {{- end }}
+    {{- with .category }}
+    category: {{ . | quote }}
+    {{- end }}
+    {{- with .priority }}
+    priority: {{ . }}
+    {{- end }}
+    {{- with .externalUrl }}
+    externalUrl: {{ . | quote }}
+    {{- end }}
+    {{- with .healthCheck }}
+    healthCheck:
+      enabled: {{ .enabled | default false }}
+      {{- with .path }}
+      path: {{ . | quote }}
+      {{- end }}
+      {{- with .intervalSeconds }}
+      intervalSeconds: {{ . }}
+      {{- end }}
+      {{- with .timeoutSeconds }}
+      timeoutSeconds: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,30 @@ nebariapp:
       - profile
       - email
       - groups
+  # landingPage controls whether and how this service appears on the Nebari
+  # landing page (requires nebari-operator with LandingPageConfig support).
+  landingPage:
+    # enabled: when true the service card is shown on the Nebari landing page.
+    enabled: false
+    # displayName: human-readable label shown on the service card (max 64 chars).
+    displayName: "JupyterHub"
+    # description: supplementary text shown on the service card (max 256 chars).
+    description: "Interactive Python notebooks for data science"
+    # icon: built-in icon ID (e.g. jupyter, grafana) or a URL to a custom image.
+    icon: "https://jupyter.org/assets/homepage/main-logo.svg"
+    # category: groups related services together on the landing page.
+    category: "Data Science"
+    # priority: sort order within a category; lower numbers appear first (0–1000).
+    priority: 1
+    # externalUrl: overrides the URL derived from spec.hostname shown on the card.
+    # externalUrl: ""
+    # healthCheck: HTTP health probe used by the landing page to mark the service
+    # reachable/unreachable. path defaults to /health; interval 10–300 s; timeout 1–30 s.
+    healthCheck:
+      enabled: true
+      path: "/hub/api/health"  # JupyterHub health endpoint
+      intervalSeconds: 30
+      timeoutSeconds: 5
 
 # Shared storage configuration (disabled - requires RWX storage class)
 sharedStorage:


### PR DESCRIPTION
## Summary

Exposes the `LandingPageConfig` and `HealthCheckConfig` fields from the nebari-operator CRD in the Helm chart, so landing page registration can be customised via `values.yaml` without patching the template.

## Changes

### `values.yaml`
- Added `nebariapp.landingPage` block with JupyterHub-appropriate defaults:
  - `enabled: false` — opt-in, not on by default
  - `displayName`, `description`, `icon`, `category`, `priority` pre-filled as examples
- Added `nebariapp.landingPage.healthCheck`:
  - `enabled: true`, `path: /hub/api/health`, `intervalSeconds: 30`, `timeoutSeconds: 5`
  - Values are within the operator's validated ranges (interval 10–300 s, timeout 1–30 s)

### `templates/nebariapp.yaml`
- Renders `spec.landingPage` when `nebariapp.landingPage` is set, including all optional sub-fields (`displayName`, `description`, `icon`, `category`, `priority`, `externalUrl`)
- Renders `spec.landingPage.healthCheck` sub-block when present

## References
- nebari-dev/nebari-operator `api/v1/nebariapp_types.go` — `LandingPageConfig` + `HealthCheckConfig` structs
- ADR 2026-03-05: webapi extracted to nebari-landing