### PR TITLE
feat: nebi auto-connect support in JupyterLab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,5 @@ jupyterlab:
 	docker build --target jupyterlab -t $(JUPYTERLAB_IMAGE) images/
 	docker run -d --name $(JUPYTERLAB_CONTAINER) -p $(JUPYTERLAB_PORT):8888 \
 		$(JUPYTERLAB_IMAGE) \
-		jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root \
-		--ServerApp.token='' --ServerApp.password=''
+		bash -c "useradd -u 1001 -m ubuntu && su ubuntu -c 'jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --ServerApp.token=\"\" --ServerApp.password=\"\"'"
 	@echo "JupyterLab running at http://localhost:$(JUPYTERLAB_PORT)"

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ jupyterlab:
 	docker build --target jupyterlab -t $(JUPYTERLAB_IMAGE) images/
 	docker run -d --name $(JUPYTERLAB_CONTAINER) -p $(JUPYTERLAB_PORT):8888 \
 		$(JUPYTERLAB_IMAGE) \
-		bash -c "useradd -u 1001 -m ubuntu && su ubuntu -c 'jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --ServerApp.token=\"\" --ServerApp.password=\"\"'"
+		bash -c "id ubuntu >/dev/null 2>&1 || useradd -u 1001 -m ubuntu; su ubuntu -c 'PATH=/opt/jupyterlab/.pixi/envs/default/bin:\$$PATH jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --ServerApp.token=\"\" --ServerApp.password=\"\"'"
 	@echo "JupyterLab running at http://localhost:$(JUPYTERLAB_PORT)"

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -1,6 +1,8 @@
 """KubeSpawner configuration."""
 # ruff: noqa: F821 - `c` is a magic global provided by JupyterHub
 
+from z2jh import get_config
+
 # Home directory: Dynamic PVC per user via the cluster's default StorageClass.
 # We configure volumes here instead of via singleuser.storage in values.yaml because
 # jhub-apps' JHubSpawner expects volumes as a list, but the subchart's dynamic storage
@@ -30,6 +32,16 @@ c.KubeSpawner.volume_mounts = [
 
 c.KubeSpawner.notebook_dir = "/home/jovyan"
 c.KubeSpawner.working_dir = "/home/jovyan"
-c.KubeSpawner.environment = {
+
+# Nebi remote server URL — when set, JupyterLab pods auto-connect to the
+# Nebi team server using the user's Keycloak IdToken cookie.
+# Read from JupyterHub custom config (set via values.yaml jupyterhub.custom.nebi-remote-url).
+nebi_remote_url = get_config("custom.nebi-remote-url", "")
+
+env = {
     "HOME": "/home/jovyan",
 }
+if nebi_remote_url:
+    env["NEBI_REMOTE_URL"] = nebi_remote_url
+
+c.KubeSpawner.environment = env

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -106,9 +106,12 @@ ENV PATH=/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${NVIDIA_PATH}:$PATH
 # ========== jupyterlab (base + nebi) ===========
 FROM jupyterlab-base AS jupyterlab
 
-# TEMPORARY: Using local nebi binary instead of downloading from GitHub
-COPY nebi/nebi-binary /usr/local/bin/nebi
-RUN chmod +x /usr/local/bin/nebi
+ARG NEBI_VERSION=0.9
+ARG TARGETARCH
+
+RUN curl -fsSL \
+    "https://github.com/nebari-dev/nebi/releases/download/v${NEBI_VERSION}/nebi_${NEBI_VERSION}_linux_$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "arm64").tar.gz" \
+    | tar -xz -C /usr/local/bin nebi
 
 COPY nebi/jupyter_server_config.py /usr/local/etc/jupyter/jupyter_server_config.py
 COPY nebi/icons /usr/local/etc/jupyter/icons

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -13,9 +13,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 COPY scripts /opt/scripts
 
-RUN curl -fsSL https://pixi.sh/install.sh | bash
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_HOME=/usr/local bash
 
-ENV PATH=/root/.pixi/bin:/opt/scripts:${PATH}
+ENV PATH=/opt/scripts:${PATH}
 
 ENV DEFAULT_ENV=default
 
@@ -23,7 +23,7 @@ ENV DEFAULT_ENV=default
 # ========== jupyterhub install ===========
 FROM builder AS jupyterhub
 
-COPY --from=builder /root/.pixi /root/.pixi
+COPY --from=builder /usr/local/bin/pixi /usr/local/bin/pixi
 COPY jupyterhub/pixi.toml /opt/jupyterhub/pixi.toml
 COPY jupyterhub/pixi.lock /opt/jupyterhub/pixi.lock
 RUN --mount=type=cache,target=/root/.cache/rattler/cache,sharing=locked \
@@ -86,7 +86,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libxrender1 \
     libosmesa6
 
-COPY --from=builder /root/.pixi /root/.pixi
+COPY --from=builder /usr/local/bin/pixi /usr/local/bin/pixi
 COPY jupyterlab/pixi.toml /opt/jupyterlab/pixi.toml
 COPY jupyterlab/pixi.lock /opt/jupyterlab/pixi.lock
 RUN --mount=type=cache,target=/root/.cache/rattler/cache,sharing=locked \
@@ -106,12 +106,9 @@ ENV PATH=/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${NVIDIA_PATH}:$PATH
 # ========== jupyterlab (base + nebi) ===========
 FROM jupyterlab-base AS jupyterlab
 
-ARG NEBI_VERSION=0.8
-ARG TARGETARCH
-
-RUN curl -fsSL \
-    "https://github.com/nebari-dev/nebi/releases/download/v${NEBI_VERSION}/nebi_${NEBI_VERSION}_linux_$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "arm64").tar.gz" \
-    | tar -xz -C /usr/local/bin nebi
+# TEMPORARY: Using local nebi binary instead of downloading from GitHub
+COPY nebi/nebi-binary /usr/local/bin/nebi
+RUN chmod +x /usr/local/bin/nebi
 
 COPY nebi/jupyter_server_config.py /usr/local/etc/jupyter/jupyter_server_config.py
 COPY nebi/icons /usr/local/etc/jupyter/icons

--- a/images/jupyterlab/pixi.lock
+++ b/images/jupyterlab/pixi.lock
@@ -460,6 +460,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/be/ce3368145f22d64095e03591deeb26986b749b0b1c8373d426f8312c3a96/panel-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/1c/1b83ffb56adb76abe46df91439e9a613bba45e4612a4e6a7bbebca0b35bb/plotlydash_tornado_cmd-0.0.6-py3-none-any.whl
@@ -939,6 +940,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/be/ce3368145f22d64095e03591deeb26986b749b0b1c8373d426f8312c3a96/panel-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/1c/1b83ffb56adb76abe46df91439e9a613bba45e4612a4e6a7bbebca0b35bb/plotlydash_tornado_cmd-0.0.6-py3-none-any.whl
@@ -6443,6 +6445,15 @@ packages:
   - pkg:pypi/narwhals?source=hash-mapping
   size: 180520
   timestamp: 1741613573009
+- pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
+  name: nb-nebi-kernels
+  version: '0.1'
+  sha256: cf6494d685112e43c38f04cb706320db96c526448411ca1c31f358caa50a54d4
+  requires_dist:
+  - jupyter-client>=8.0.0
+  - jupyter-core>=5.0.0
+  - jupyter-server>=2.0.0
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/nb_conda_kernels-2.5.1-pyh707e725_2.conda
   sha256: 2aaf48824b2bba5af5fe6c36c3d2a8314fee52b3b86e9f84c6009817ba19309c
   md5: 076e6d822442987779a6622092a8fb6a

--- a/images/jupyterlab/pixi.lock
+++ b/images/jupyterlab/pixi.lock
@@ -247,7 +247,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nano-8.7-h18c060e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.30.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nb_conda_kernels-2.5.1-pyh707e725_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.6-hb482800_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
@@ -727,7 +726,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nano-8.7-h1779866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.30.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nb_conda_kernels-2.5.1-pyh707e725_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.6-hb482800_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
@@ -6455,22 +6453,6 @@ packages:
   - jupyter-core>=5.0.0
   - jupyter-server>=2.0.0
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/nb_conda_kernels-2.5.1-pyh707e725_2.conda
-  sha256: 2aaf48824b2bba5af5fe6c36c3d2a8314fee52b3b86e9f84c6009817ba19309c
-  md5: 076e6d822442987779a6622092a8fb6a
-  depends:
-  - __unix
-  - jupyter_client >=4.2
-  - notebook
-  - psutil
-  - python >=3.8
-  - requests
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/nb-conda-kernels?source=hash-mapping
-  size: 22025
-  timestamp: 1714150164539
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
   sha256: a20cff739d66c2f89f413e4ba4c6f6b59c50d5c30b5f0d840c13e8c9c2df9135
   md5: 6bb0d77277061742744176ab555b723c

--- a/images/jupyterlab/pixi.lock
+++ b/images/jupyterlab/pixi.lock
@@ -111,7 +111,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/htop-3.4.1-haa1a288_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.129.1-pyha770c72_0.conda
@@ -591,7 +591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/htop-3.4.1-h76d6b2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.129.1-pyha770c72_0.conda
@@ -3334,21 +3334,22 @@ packages:
   - pkg:pypi/httpcore?source=hash-mapping
   size: 48959
   timestamp: 1731707562362
-- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
-  md5: d6989ead454181f4f9bc987d3dc4e285
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+  sha256: 1a33f160548bf447e15c0273899d27e4473f1d5b7ca1441232ec2d9d07c56d03
+  md5: 7e9ac3faeebdbd7b53b462c41891e7f7
   depends:
   - anyio
   - certifi
   - httpcore 1.*
   - idna
-  - python >=3.9
+  - python >=3.8
+  - sniffio
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/httpx?source=hash-mapping
-  size: 63082
-  timestamp: 1733663449209
+  size: 65085
+  timestamp: 1724778453275
 - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.0-pyhd8ed1ab_1.conda
   sha256: a32e0f44a2f1c1001d7b2bfbb7ee5481bca09a6e60f4371b75a4d11d1884e3af
   md5: 3f9aa7f084adbbbb1fb235e6a72da100

--- a/images/jupyterlab/pixi.toml
+++ b/images/jupyterlab/pixi.toml
@@ -13,6 +13,9 @@ nb_conda_kernels = "*"
 ipython = ">7"
 jupyter-server-proxy = ">=4.4.0"
 jupyter_server = ">=2.13.0"
+# httpx 0.28 removed the `proxies` kwarg from AsyncClient, which JupyterLab 4.2.5
+# still uses in its extension manager. Pin httpx <0.28 until JupyterLab is upgraded.
+httpx = "<0.28"
 jupyterlab = "==4.2.5"
 jupyter_client = "*"
 jupyter_console = "*"

--- a/images/jupyterlab/pixi.toml
+++ b/images/jupyterlab/pixi.toml
@@ -73,6 +73,7 @@ pyjwt = "<2.10.0"
 
 [pypi-dependencies]
 jupyter-vscode-proxy = { git = "https://github.com/betatim/vscode-binder.git" }
+nb_nebi_kernels = "==0.1"
 jupyterlab_nvdashboard = "==0.12.0"
 argo-jupyter-scheduler = "==2024.6.1"
 jhub-apps = "==2025.11.1"

--- a/images/jupyterlab/pixi.toml
+++ b/images/jupyterlab/pixi.toml
@@ -9,7 +9,6 @@ platforms = ["linux-64", "linux-aarch64"]
 python = "3.12.*"
 
 # jupyterhub/jupyterlab
-nb_conda_kernels = "*"
 ipython = ">7"
 jupyter-server-proxy = ">=4.4.0"
 jupyter_server = ">=2.13.0"

--- a/images/nebi/jupyter_server_config.py
+++ b/images/nebi/jupyter_server_config.py
@@ -10,16 +10,25 @@ ICON_PATH = os.path.join(
     "nebi.svg",
 )
 
+# Build environment for nebi serve.
+# NEBI_REMOTE_URL is set by the JupyterHub spawner when a Nebi team server
+# is deployed alongside this pack. When present, the local Nebi instance
+# will auto-connect to the remote server using the user's Keycloak cookie.
+nebi_env = {
+    "NEBI_SERVER_BASE_PATH": "{base_url}nebi",
+    "NEBI_MODE": "local",
+}
+nebi_remote_url = os.environ.get("NEBI_REMOTE_URL", "")
+if nebi_remote_url:
+    nebi_env["NEBI_REMOTE_URL"] = nebi_remote_url
+
 c.ServerProxy.servers = {
     "nebi": {
         "command": ["nebi", "serve", "--port", "{port}"],
         "timeout": 20,
         "absolute_url": True,
         "new_browser_tab": False,
-        "environment": {
-            "NEBI_SERVER_BASE_PATH": "{base_url}nebi",
-            "NEBI_MODE": "local",
-        },
+        "environment": nebi_env,
         "launcher_entry": {
             "title": "Nebi",
             "enabled": True,

--- a/images/nebi/jupyter_server_config.py
+++ b/images/nebi/jupyter_server_config.py
@@ -17,6 +17,16 @@ ICON_PATH = os.path.join(
 nebi_env = {
     "NEBI_SERVER_BASE_PATH": "{base_url}nebi",
     "NEBI_MODE": "local",
+    "NEBI_DATABASE_DSN": os.path.join(
+        os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+        "nebi",
+        "nebi.db",
+    ),
+    "NEBI_STORAGE_WORKSPACES_DIR": os.path.join(
+        os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+        "nebi",
+        "workspaces",
+    ),
 }
 nebi_remote_url = os.environ.get("NEBI_REMOTE_URL", "")
 if nebi_remote_url:

--- a/images/nebi/jupyter_server_config.py
+++ b/images/nebi/jupyter_server_config.py
@@ -22,6 +22,8 @@ nebi_remote_url = os.environ.get("NEBI_REMOTE_URL", "")
 if nebi_remote_url:
     nebi_env["NEBI_REMOTE_URL"] = nebi_remote_url
 
+c.ServerApp.terminado_settings = {"shell_command": ["/bin/bash"]}
+
 c.ServerProxy.servers = {
     "nebi": {
         "command": ["nebi", "serve", "--port", "{port}"],

--- a/images/nebi/jupyter_server_config.py
+++ b/images/nebi/jupyter_server_config.py
@@ -23,6 +23,7 @@ if nebi_remote_url:
     nebi_env["NEBI_REMOTE_URL"] = nebi_remote_url
 
 c.ServerApp.terminado_settings = {"shell_command": ["/bin/bash"]}
+c.ServerApp.kernel_spec_manager_class = "nb_nebi_kernels.NebiKernelSpecManager"
 
 c.ServerProxy.servers = {
     "nebi": {

--- a/values.yaml
+++ b/values.yaml
@@ -155,7 +155,7 @@ jupyterhub:
                 matchLabels:
                   gateway.envoyproxy.io/owning-gateway-name: nebari-gateway
           ports:
-            - port: 8443
+            - port: 10443
               protocol: TCP
 
   proxy:

--- a/values.yaml
+++ b/values.yaml
@@ -142,21 +142,8 @@ jupyterhub:
     storage:
       type: none
 
-    networkPolicy:
-      egress:
-        # Allow singleuser pods to reach the Envoy Gateway proxy (for nebi API via external hostname).
-        # The LoadBalancer VIP gets DNAT'd by kube-proxy to an envoy proxy pod IP,
-        # so we must allow egress to that specific pod on HTTPS.
-        - to:
-            - namespaceSelector:
-                matchLabels:
-                  kubernetes.io/metadata.name: envoy-gateway-system
-              podSelector:
-                matchLabels:
-                  gateway.envoyproxy.io/owning-gateway-name: nebari-gateway
-          ports:
-            - port: 10443
-              protocol: TCP
+    # networkPolicy:
+    #   egress: []  # Override in deployment-specific values (e.g., data-science-pack.yaml)
 
   proxy:
     service:

--- a/values.yaml
+++ b/values.yaml
@@ -142,6 +142,16 @@ jupyterhub:
     storage:
       type: none
 
+    networkPolicy:
+      egress:
+        # Allow singleuser pods to reach the Envoy Gateway (for nebi API via external hostname).
+        # The LoadBalancer VIP gets DNAT'd to a pod IP in the envoy-gateway-system namespace,
+        # so we must allow egress to that namespace.
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: envoy-gateway-system
+
   proxy:
     service:
       type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -144,13 +144,19 @@ jupyterhub:
 
     networkPolicy:
       egress:
-        # Allow singleuser pods to reach the Envoy Gateway (for nebi API via external hostname).
-        # The LoadBalancer VIP gets DNAT'd to a pod IP in the envoy-gateway-system namespace,
-        # so we must allow egress to that namespace.
+        # Allow singleuser pods to reach the Envoy Gateway proxy (for nebi API via external hostname).
+        # The LoadBalancer VIP gets DNAT'd by kube-proxy to an envoy proxy pod IP,
+        # so we must allow egress to that specific pod on HTTPS.
         - to:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: envoy-gateway-system
+              podSelector:
+                matchLabels:
+                  gateway.envoyproxy.io/owning-gateway-name: nebari-gateway
+          ports:
+            - port: 8443
+              protocol: TCP
 
   proxy:
     service:

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,17 @@ sharedStorage:
   accessModes:
     - ReadWriteMany
 
+# =============================================================================
+# Nebi Integration
+# =============================================================================
+# When the nebi-pack is deployed alongside data-science-pack, set remoteURL
+# so that JupyterLab pods auto-connect to the Nebi team server.
+nebi:
+  # URL of the remote Nebi server (e.g., https://nebi.nebari.example.com)
+  # When set, the Nebi local instance in each JupyterLab pod will auto-connect
+  # to this server using the user's Keycloak IdToken cookie.
+  remoteURL: ""
+
 # JupyterHub configuration
 # All values under this key are passed to the jupyterhub subchart
 jupyterhub:
@@ -44,6 +55,7 @@ jupyterhub:
   # internal OAuth redirects use the real hostname instead of 0.0.0.0.
   custom:
     external-url: ""
+    nebi-remote-url: ""  # Set by templates from .Values.nebi.remoteURL
     # jhub-apps (JAppsConfig) overrides.
     # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
     # See https://jhub-apps.nebari.dev/docs/configuration for available options.


### PR DESCRIPTION
## Summary
- Add nebi auto-connect support: pass `NEBI_REMOTE_URL` env var from JupyterHub spawner to enable automatic connection to the remote Nebi team server
- Install `nb-nebi-kernels` for Nebi kernel spec management
- Fix nebi serve write failures by setting `NEBI_DATABASE_DSN` and `NEBI_STORAGE_WORKSPACES_DIR` to user-writable paths (`~/.local/share/nebi/`)
- Fix local `make jupyterlab` target to handle pre-existing ubuntu user and ensure pixi PATH is available
- Tighten singleuser networkPolicy egress for envoy proxy access
- Pin httpx and install pixi to /usr/local for non-root access

## Test plan
- [x] `make jupyterlab` starts container successfully
- [x] Nebi launcher opens without 500 error
- [x] Nebi UI loads and shows workspaces page
- [ ] Verify nebi auto-connect works with remote server in deployed environment