### PR TITLE
fix: Merge extraEnv from values.yaml instead of replacing it

### DIFF
--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -38,9 +38,10 @@ c.KubeSpawner.working_dir = "/home/jovyan"
 # Read from JupyterHub custom config (set via values.yaml jupyterhub.custom.nebi-remote-url).
 nebi_remote_url = get_config("custom.nebi-remote-url", "")
 
-env = {
-    "HOME": "/home/jovyan",
-}
+# Start with extraEnv from values.yaml so deployers can inject env vars
+# (e.g. MLFLOW_TRACKING_URI) without modifying this config file.
+env = dict(get_config("singleuser.extraEnv", {}))
+env["HOME"] = "/home/jovyan"
 if nebi_remote_url:
     env["NEBI_REMOTE_URL"] = nebi_remote_url
 


### PR DESCRIPTION
## Summary

- `01-spawner.py` sets `c.KubeSpawner.environment` to a hardcoded dict, which **completely replaces** any `singleuser.extraEnv` values from `values.yaml`
- This makes it impossible for deployers to inject env vars (e.g. `MLFLOW_TRACKING_URI`) into singleuser pods via Helm values — the z2jh `extraEnv` mechanism is silently ignored
- Fix: initialize the env dict from `get_config("singleuser.extraEnv")` so deployer values are preserved

## Before

```python
env = {
    "HOME": "/home/jovyan",
}
c.KubeSpawner.environment = env  # replaces everything
```

## After

```python
env = dict(get_config("singleuser.extraEnv", {}))  # start with deployer values
env["HOME"] = "/home/jovyan"
c.KubeSpawner.environment = env
```

## Test plan

- [x] Deploy with `jupyterhub.singleuser.extraEnv.MLFLOW_TRACKING_URI` set in ArgoCD values
- [x] Start a new JupyterLab session
- [x] Verify `echo $MLFLOW_TRACKING_URI` returns the expected value
- [x] Verify `echo $HOME` still returns `/home/jovyan`