### PR TITLE
feat: auto-authenticate Nebi at JupyterLab spawn time

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         default: false
         type: boolean
+      nebi_image:
+        description: "Nebi Docker image to copy binary from (e.g., quay.io/nebari/nebi:sha-abc). Leave empty to use GitHub release."
+        required: false
+        default: ""
+        type: string
     secrets:
       QUAY_TOKEN:
         required: true
@@ -68,22 +73,21 @@ jobs:
           file: images/Dockerfile
           target: ${{ inputs.target }}
           platforms: linux/amd64
-          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }},quay.io/${{ env.DOCKER_ORG }}/${{ inputs.image }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }},quay.io/${{ env.DOCKER_ORG }}/${{ inputs.image }}",push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }}:cache-linux-amd64
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:cache-linux-amd64,mode=max', github.repository_owner, inputs.image) || '' }}
           build-args: |
             BASE_IMAGE=${{ inputs.base_image }}
             GPU=${{ inputs.gpu }}
+            NEBI_IMAGE=${{ inputs.nebi_image }}
 
       - name: "Export digest"
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: "Upload digest"
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.image }}-digest-linux-amd64
@@ -119,22 +123,21 @@ jobs:
           file: images/Dockerfile
           target: ${{ inputs.target }}
           platforms: linux/arm64
-          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }},quay.io/${{ env.DOCKER_ORG }}/${{ inputs.image }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }},quay.io/${{ env.DOCKER_ORG }}/${{ inputs.image }}",push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }}:cache-linux-arm64
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:cache-linux-arm64,mode=max', github.repository_owner, inputs.image) || '' }}
           build-args: |
             BASE_IMAGE=${{ inputs.base_image }}
             GPU=${{ inputs.gpu }}
+            NEBI_IMAGE=${{ inputs.nebi_image }}
 
       - name: "Export digest"
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: "Upload digest"
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.image }}-digest-linux-arm64
@@ -145,7 +148,7 @@ jobs:
   merge:
     name: "Merge"
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' && !cancelled() && !failure()
+    if: "!cancelled() && !failure()"
     needs: [build-amd64, build-arm64]
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -177,6 +180,7 @@ jobs:
             quay.io/${{ env.DOCKER_ORG }}/${{ inputs.image }}
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=ref,event=tag
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -59,6 +59,7 @@ class EnvoyOIDCAuthenticator(Authenticator):
             "name": username,
             "admin": is_admin,
             "groups": groups,
+            "auth_state": {"id_token": id_token},
         }
 
 
@@ -66,3 +67,4 @@ if get_config("custom.external-url", ""):
     c.JupyterHub.authenticator_class = EnvoyOIDCAuthenticator
     # All users who pass Keycloak auth at the gateway are allowed
     c.Authenticator.allow_all = True
+    c.Authenticator.enable_auth_state = True

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -21,12 +21,25 @@ class EnvoyOIDCAuthenticator(Authenticator):
     auto_login = True
 
     async def authenticate(self, handler, data=None):
-        # Find the IdToken cookie (Envoy uses IdToken-<suffix>)
+        # Envoy Gateway stores two tokens as cookies after OIDC authentication:
+        #
+        # IdToken (IdToken-<suffix>):
+        #   JWT containing user identity claims (sub, email, groups, etc.).
+        #   The `aud` claim is set to THIS client (JupyterHub's Keycloak client).
+        #   Used here to extract the username and groups.
+        #
+        # AccessToken (AccessToken-<suffix>):
+        #   Credential for accessing resources. Can be exchanged at Keycloak's
+        #   token endpoint (RFC 8693) for a token with a different audience —
+        #   e.g., exchanging a JupyterHub access token for a Nebi ID token.
+        #   Stored in auth_state for the spawner's pre_spawn_hook to use.
         id_token = None
+        access_token = None
         for name, value in handler.request.cookies.items():
             if name.startswith("IdToken"):
                 id_token = value.value
-                break
+            elif name.startswith("AccessToken"):
+                access_token = value.value
 
         if not id_token:
             self.log.warning("No IdToken cookie found")
@@ -59,7 +72,10 @@ class EnvoyOIDCAuthenticator(Authenticator):
             "name": username,
             "admin": is_admin,
             "groups": groups,
-            "auth_state": {"id_token": id_token},
+            "auth_state": {
+                "id_token": id_token,
+                "access_token": access_token,
+            },
         }
 
 

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -33,13 +33,21 @@ class EnvoyOIDCAuthenticator(Authenticator):
         #   token endpoint (RFC 8693) for a token with a different audience —
         #   e.g., exchanging a JupyterHub access token for a Nebi ID token.
         #   Stored in auth_state for the spawner's pre_spawn_hook to use.
+        #
+        # RefreshToken (RefreshToken-<suffix>):
+        #   Long-lived token for obtaining fresh access tokens. Access tokens
+        #   expire in minutes, so the pre_spawn_hook uses the refresh token
+        #   to get a fresh access token before doing the exchange.
         id_token = None
         access_token = None
+        refresh_token = None
         for name, value in handler.request.cookies.items():
             if name.startswith("IdToken"):
                 id_token = value.value
             elif name.startswith("AccessToken"):
                 access_token = value.value
+            elif name.startswith("RefreshToken"):
+                refresh_token = value.value
 
         if not id_token:
             self.log.warning("No IdToken cookie found")
@@ -75,6 +83,7 @@ class EnvoyOIDCAuthenticator(Authenticator):
             "auth_state": {
                 "id_token": id_token,
                 "access_token": access_token,
+                "refresh_token": refresh_token,
             },
         }
 

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -81,9 +81,11 @@ class EnvoyOIDCAuthenticator(Authenticator):
             "admin": is_admin,
             "groups": groups,
             "auth_state": {
-                "id_token": id_token,
-                "access_token": access_token,
-                "refresh_token": refresh_token,
+                k: v for k, v in {
+                    "id_token": id_token,
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                }.items() if v is not None
             },
         }
 

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -47,6 +47,34 @@ c.KubeSpawner.working_dir = "/home/jovyan"
 
 
 # ---------------------------------------------------------------------------
+# Nebi binary (init container)
+# ---------------------------------------------------------------------------
+# Copy the nebi binary from the nebi server image into the JupyterLab pod
+# so the version matches what the deployment specifies, not what was baked
+# into the jupyterlab image at build time.
+nebi_image = get_config("custom.nebi-image", "")
+if nebi_image:
+    c.KubeSpawner.volumes.append({
+        "name": "nebi-bin",
+        "emptyDir": {},
+    })
+    c.KubeSpawner.volume_mounts.append({
+        "name": "nebi-bin",
+        "mountPath": "/usr/local/bin/nebi",
+        "subPath": "nebi",
+    })
+    c.KubeSpawner.init_containers.append({
+        "name": "install-nebi",
+        "image": nebi_image,
+        "command": ["cp", "/app/nebi", "/nebi-bin/nebi"],
+        "volumeMounts": [{
+            "name": "nebi-bin",
+            "mountPath": "/nebi-bin",
+        }],
+    })
+
+
+# ---------------------------------------------------------------------------
 # Environment variables
 # ---------------------------------------------------------------------------
 env = {

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -1,9 +1,20 @@
 """KubeSpawner configuration."""
 # ruff: noqa: F821 - `c` is a magic global provided by JupyterHub
 
+import json
+import logging
+from urllib.parse import urlencode
+
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from z2jh import get_config
 
-# Home directory: Dynamic PVC per user via the cluster's default StorageClass.
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+# Dynamic PVC per user via the cluster's default StorageClass.
 # We configure volumes here instead of via singleuser.storage in values.yaml because
 # jhub-apps' JHubSpawner expects volumes as a list, but the subchart's dynamic storage
 # generates a dict, causing a TraitError on startup.
@@ -33,52 +44,120 @@ c.KubeSpawner.volume_mounts = [
 c.KubeSpawner.notebook_dir = "/home/jovyan"
 c.KubeSpawner.working_dir = "/home/jovyan"
 
-# Nebi remote server URL — when set, JupyterLab pods auto-connect to the
-# Nebi team server using the user's Keycloak IdToken cookie.
-# Read from JupyterHub custom config (set via values.yaml jupyterhub.custom.nebi-remote-url).
-nebi_remote_url = get_config("custom.nebi-remote-url", "")
 
+# ---------------------------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------------------------
 env = {
     "HOME": "/home/jovyan",
 }
+
+nebi_remote_url = get_config("custom.nebi-remote-url", "")
 if nebi_remote_url:
     env["NEBI_REMOTE_URL"] = nebi_remote_url
 
 c.KubeSpawner.environment = env
 
-# Nebi auto-authentication: exchange the user's Keycloak IdToken for a Nebi JWT
-# at spawn time so JupyterLab pods are pre-authenticated with the remote Nebi server.
-nebi_internal_url = get_config("custom.nebi-internal-url", "")
 
-if nebi_remote_url and nebi_internal_url:
-    from tornado.httpclient import AsyncHTTPClient, HTTPRequest
-    import json as _json
+# ---------------------------------------------------------------------------
+# Nebi auto-authentication (Keycloak token exchange, RFC 8693)
+# ---------------------------------------------------------------------------
+# At spawn time, exchange the user's JupyterHub access token for a
+# Nebi-audience ID token via Keycloak, then convert that into a Nebi JWT.
+#
+# Why token exchange? The IdToken in auth_state has aud=jupyterhub-client,
+# but Nebi's session endpoint only accepts tokens with aud=nebi-client.
+# Token exchange lets Keycloak issue a new ID token for the correct audience.
 
-    async def _nebi_pre_spawn_hook(spawner):
-        """Exchange Keycloak IdToken for Nebi JWT at spawn time."""
-        auth_state = await spawner.user.get_auth_state()
-        if not auth_state or "id_token" not in auth_state:
-            spawner.log.warning("No IdToken in auth_state, skipping Nebi auto-auth")
+
+async def _exchange_access_token_for_nebi_id_token(
+    access_token, keycloak_url, nebi_client_id, hub_client_id, hub_client_secret,
+):
+    """Exchange a JupyterHub access token for a Nebi-audience ID token via Keycloak.
+
+    The access token proves the user is authenticated. Keycloak validates it
+    and issues a new ID token with aud=nebi-client-id.
+
+    Returns the Nebi ID token string, or None on failure.
+    """
+    body = urlencode({
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": access_token,
+        "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        "audience": nebi_client_id,
+        "client_id": hub_client_id,
+        "client_secret": hub_client_secret,
+        "requested_token_type": "urn:ietf:params:oauth:token-type:id_token",
+    })
+    resp = await AsyncHTTPClient().fetch(HTTPRequest(
+        keycloak_url,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        body=body,
+        request_timeout=10,
+    ))
+    return json.loads(resp.body).get("access_token", "")
+
+
+async def _exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
+    """Exchange a Nebi-audience ID token for a Nebi JWT via the session endpoint.
+
+    Nebi verifies the ID token (aud must match nebi-client-id), finds/creates
+    the user, syncs roles from groups, and returns a Nebi JWT (24h expiry).
+
+    Returns the Nebi JWT string, or None on failure.
+    """
+    session_url = f"{nebi_internal_url.rstrip('/')}/api/v1/auth/session"
+    resp = await AsyncHTTPClient().fetch(HTTPRequest(
+        session_url,
+        method="GET",
+        headers={"Cookie": f"IdToken={nebi_id_token}"},
+        request_timeout=10,
+    ))
+    return json.loads(resp.body).get("token", "")
+
+
+async def _nebi_pre_spawn_hook(spawner):
+    """Authenticate the user with the remote Nebi server at spawn time.
+
+    Reads the Keycloak access token from auth_state, exchanges it for a
+    Nebi JWT, and injects it as NEBI_AUTH_TOKEN into the pod environment.
+    Non-fatal: if any step fails, the pod still spawns without auto-auth.
+    """
+    auth_state = await spawner.user.get_auth_state()
+    if not auth_state or not auth_state.get("access_token"):
+        log.warning("No access_token in auth_state for %s, skipping Nebi auto-auth", spawner.user.name)
+        return
+
+    keycloak_url = get_config("custom.keycloak-token-url", "")
+    nebi_cid = get_config("custom.nebi-client-id", "")
+    hub_cid = get_config("custom.jupyterhub-client-id", "")
+    hub_secret = get_config("custom.jupyterhub-client-secret", "")
+    nebi_url = get_config("custom.nebi-internal-url", "")
+
+    if not all([keycloak_url, nebi_cid, hub_cid, hub_secret, nebi_url]):
+        log.warning("Nebi auto-auth not fully configured, skipping")
+        return
+
+    try:
+        nebi_id_token = await _exchange_access_token_for_nebi_id_token(
+            auth_state["access_token"], keycloak_url, nebi_cid, hub_cid, hub_secret,
+        )
+        if not nebi_id_token:
+            log.warning("Keycloak token exchange returned no token for %s", spawner.user.name)
             return
 
-        session_url = f"{nebi_internal_url.rstrip('/')}/api/v1/auth/session"
-        try:
-            request = HTTPRequest(
-                session_url,
-                method="GET",
-                headers={"Cookie": f"IdToken={auth_state['id_token']}"},
-                request_timeout=10,
-            )
-            response = await AsyncHTTPClient().fetch(request)
-            data = _json.loads(response.body)
-            token = data.get("token", "")
-            if token:
-                spawner.environment["NEBI_AUTH_TOKEN"] = token
-                spawner.log.info("Nebi auto-auth succeeded for %s", spawner.user.name)
-            else:
-                spawner.log.warning("Nebi session response had no token")
-        except Exception:
-            # Non-fatal: pod still spawns, user just won't be auto-authenticated
-            spawner.log.exception("Nebi auto-auth failed (pod will still spawn)")
+        nebi_jwt = await _exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_url)
+        if not nebi_jwt:
+            log.warning("Nebi session returned no token for %s", spawner.user.name)
+            return
 
+        spawner.environment["NEBI_AUTH_TOKEN"] = nebi_jwt
+        log.info("Nebi auto-auth succeeded for %s", spawner.user.name)
+    except Exception:
+        log.exception("Nebi auto-auth failed for %s (pod will still spawn)", spawner.user.name)
+
+
+# Only register the hook when Nebi integration is configured.
+if nebi_remote_url and get_config("custom.nebi-internal-url", ""):
     c.KubeSpawner.pre_spawn_hook = _nebi_pre_spawn_hook

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -115,13 +115,20 @@ async def _exchange_access_token_for_nebi_id_token(
         "client_secret": hub_client_secret,
         "requested_token_type": "urn:ietf:params:oauth:token-type:id_token",
     })
-    resp = await AsyncHTTPClient().fetch(HTTPRequest(
-        keycloak_url,
-        method="POST",
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        body=body,
-        request_timeout=10,
-    ))
+    try:
+        resp = await AsyncHTTPClient().fetch(HTTPRequest(
+            keycloak_url,
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=body,
+            request_timeout=10,
+        ))
+    except Exception as exc:
+        resp_body = getattr(exc, "response", None)
+        if resp_body is not None:
+            resp_body = resp_body.body.decode() if resp_body.body else ""
+        log.error("Keycloak token exchange error: %s response=%s", exc, resp_body)
+        raise
     return json.loads(resp.body).get("access_token", "")
 
 

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -113,7 +113,6 @@ async def _exchange_access_token_for_nebi_id_token(
         "audience": nebi_client_id,
         "client_id": hub_client_id,
         "client_secret": hub_client_secret,
-        "requested_token_type": "urn:ietf:params:oauth:token-type:id_token",
     })
     try:
         resp = await AsyncHTTPClient().fetch(HTTPRequest(
@@ -129,7 +128,9 @@ async def _exchange_access_token_for_nebi_id_token(
             resp_body = resp_body.body.decode() if resp_body.body else ""
         log.error("Keycloak token exchange error: %s response=%s", exc, resp_body)
         raise
-    return json.loads(resp.body).get("access_token", "")
+    data = json.loads(resp.body)
+    # Prefer id_token if present (has user identity claims), fall back to access_token
+    return data.get("id_token") or data.get("access_token", "")
 
 
 async def _exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -115,13 +115,20 @@ async def _refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_
         "client_id": hub_client_id,
         "client_secret": hub_client_secret,
     })
-    resp = await AsyncHTTPClient().fetch(HTTPRequest(
-        keycloak_url,
-        method="POST",
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        body=body,
-        request_timeout=10,
-    ))
+    try:
+        resp = await AsyncHTTPClient().fetch(HTTPRequest(
+            keycloak_url,
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=body,
+            request_timeout=10,
+        ))
+    except Exception as exc:
+        resp_body = getattr(exc, "response", None)
+        if resp_body is not None:
+            resp_body = resp_body.body.decode() if resp_body.body else ""
+        log.error("Keycloak token refresh error: %s response=%s", exc, resp_body)
+        raise
     return json.loads(resp.body).get("access_token", "")
 
 
@@ -176,6 +183,7 @@ async def _exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
         method="GET",
         headers={"Cookie": f"IdToken={nebi_id_token}"},
         request_timeout=10,
+        follow_redirects=False,
     ))
     return json.loads(resp.body).get("token", "")
 
@@ -206,7 +214,7 @@ async def _nebi_pre_spawn_hook(spawner):
     try:
         # Refresh the access token first — it expires in minutes, but the
         # refresh token (from Envoy's RefreshToken cookie) lasts much longer.
-        access_token = auth_state.get("access_token", "")
+        access_token = auth_state.get("access_token") or ""
         refresh_token = auth_state.get("refresh_token")
         if refresh_token:
             access_token = await _refresh_access_token(
@@ -231,7 +239,7 @@ async def _nebi_pre_spawn_hook(spawner):
             log.warning("Nebi session returned no token for %s", spawner.user.name)
             return
 
-        spawner.environment["NEBI_AUTH_TOKEN"] = nebi_jwt
+        spawner.environment = {**spawner.environment, "NEBI_AUTH_TOKEN": nebi_jwt}
         log.info("Nebi auto-auth succeeded for %s", spawner.user.name)
     except Exception:
         log.exception("Nebi auto-auth failed for %s (pod will still spawn)", spawner.user.name)

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -66,7 +66,8 @@ if nebi_image:
     c.KubeSpawner.init_containers.append({
         "name": "install-nebi",
         "image": nebi_image,
-        "command": ["cp", "/app/nebi", "/nebi-bin/nebi"],
+        "command": ["sh", "-c", "cp /app/nebi /nebi-bin/nebi && chmod +x /nebi-bin/nebi"],
+        "imagePullPolicy": get_config("custom.nebi-image-pull-policy", "IfNotPresent"),
         "volumeMounts": [{
             "name": "nebi-bin",
             "mountPath": "/nebi-bin",

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -71,6 +71,31 @@ c.KubeSpawner.environment = env
 # Token exchange lets Keycloak issue a new ID token for the correct audience.
 
 
+async def _refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_client_secret):
+    """Use the refresh token to get a fresh access token from Keycloak.
+
+    Access tokens expire in minutes. The refresh token (stored in auth_state
+    from Envoy's RefreshToken cookie) has a much longer lifetime and can be
+    used to obtain a fresh access token without user interaction.
+
+    Returns the new access token string, or None on failure.
+    """
+    body = urlencode({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": hub_client_id,
+        "client_secret": hub_client_secret,
+    })
+    resp = await AsyncHTTPClient().fetch(HTTPRequest(
+        keycloak_url,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        body=body,
+        request_timeout=10,
+    ))
+    return json.loads(resp.body).get("access_token", "")
+
+
 async def _exchange_access_token_for_nebi_id_token(
     access_token, keycloak_url, nebi_client_id, hub_client_id, hub_client_secret,
 ):
@@ -126,8 +151,8 @@ async def _nebi_pre_spawn_hook(spawner):
     Non-fatal: if any step fails, the pod still spawns without auto-auth.
     """
     auth_state = await spawner.user.get_auth_state()
-    if not auth_state or not auth_state.get("access_token"):
-        log.warning("No access_token in auth_state for %s, skipping Nebi auto-auth", spawner.user.name)
+    if not auth_state:
+        log.warning("No auth_state for %s, skipping Nebi auto-auth", spawner.user.name)
         return
 
     keycloak_url = get_config("custom.keycloak-token-url", "")
@@ -142,8 +167,23 @@ async def _nebi_pre_spawn_hook(spawner):
         return
 
     try:
+        # Refresh the access token first — it expires in minutes, but the
+        # refresh token (from Envoy's RefreshToken cookie) lasts much longer.
+        access_token = auth_state.get("access_token", "")
+        refresh_token = auth_state.get("refresh_token")
+        if refresh_token:
+            access_token = await _refresh_access_token(
+                refresh_token, keycloak_url, hub_cid, hub_secret,
+            )
+            if not access_token:
+                log.warning("Token refresh returned no access token for %s", spawner.user.name)
+                return
+        elif not access_token:
+            log.warning("No access_token or refresh_token for %s, skipping", spawner.user.name)
+            return
+
         nebi_id_token = await _exchange_access_token_for_nebi_id_token(
-            auth_state["access_token"], keycloak_url, nebi_cid, hub_cid, hub_secret,
+            access_token, keycloak_url, nebi_cid, hub_cid, hub_secret,
         )
         if not nebi_id_token:
             log.warning("Keycloak token exchange returned no token for %s", spawner.user.name)

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 from urllib.parse import urlencode
 
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
@@ -132,7 +133,8 @@ async def _nebi_pre_spawn_hook(spawner):
     keycloak_url = get_config("custom.keycloak-token-url", "")
     nebi_cid = get_config("custom.nebi-client-id", "")
     hub_cid = get_config("custom.jupyterhub-client-id", "")
-    hub_secret = get_config("custom.jupyterhub-client-secret", "")
+    # Read from env var (mounted from K8s secret) to avoid plaintext in Helm values.
+    hub_secret = os.environ.get("JUPYTERHUB_OIDC_CLIENT_SECRET", "")
     nebi_url = get_config("custom.nebi-internal-url", "")
 
     if not all([keycloak_url, nebi_cid, hub_cid, hub_secret, nebi_url]):

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -45,3 +45,40 @@ if nebi_remote_url:
     env["NEBI_REMOTE_URL"] = nebi_remote_url
 
 c.KubeSpawner.environment = env
+
+# Nebi auto-authentication: exchange the user's Keycloak IdToken for a Nebi JWT
+# at spawn time so JupyterLab pods are pre-authenticated with the remote Nebi server.
+nebi_internal_url = get_config("custom.nebi-internal-url", "")
+
+if nebi_remote_url and nebi_internal_url:
+    from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+    import json as _json
+
+    async def _nebi_pre_spawn_hook(spawner):
+        """Exchange Keycloak IdToken for Nebi JWT at spawn time."""
+        auth_state = await spawner.user.get_auth_state()
+        if not auth_state or "id_token" not in auth_state:
+            spawner.log.warning("No IdToken in auth_state, skipping Nebi auto-auth")
+            return
+
+        session_url = f"{nebi_internal_url.rstrip('/')}/api/v1/auth/session"
+        try:
+            request = HTTPRequest(
+                session_url,
+                method="GET",
+                headers={"Cookie": f"IdToken={auth_state['id_token']}"},
+                request_timeout=10,
+            )
+            response = await AsyncHTTPClient().fetch(request)
+            data = _json.loads(response.body)
+            token = data.get("token", "")
+            if token:
+                spawner.environment["NEBI_AUTH_TOKEN"] = token
+                spawner.log.info("Nebi auto-auth succeeded for %s", spawner.user.name)
+            else:
+                spawner.log.warning("Nebi session response had no token")
+        except Exception:
+            # Non-fatal: pod still spawns, user just won't be auto-authenticated
+            spawner.log.exception("Nebi auto-auth failed (pod will still spawn)")
+
+    c.KubeSpawner.pre_spawn_hook = _nebi_pre_spawn_hook

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -103,15 +103,28 @@ ENV NVIDIA_PATH=/usr/local/nvidia/bin
 ENV PATH=/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${NVIDIA_PATH}:$PATH
 
 
+# ========== nebi-source (resolve nebi binary) ===========
+# When NEBI_IMAGE is set (e.g., quay.io/nebari/nebi:sha-abc1234), the binary is
+# copied from that image. Otherwise, downloaded from the GitHub release.
+# Useful for testing unreleased nebi versions.
+ARG NEBI_IMAGE=""
+FROM ${NEBI_IMAGE:-scratch} AS nebi-source
+
 # ========== jupyterlab (base + nebi) ===========
 FROM jupyterlab-base AS jupyterlab
 
 ARG NEBI_VERSION=0.9
 ARG TARGETARCH
 
-RUN curl -fsSL \
-    "https://github.com/nebari-dev/nebi/releases/download/v${NEBI_VERSION}/nebi_${NEBI_VERSION}_linux_$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "arm64").tar.gz" \
-    | tar -xz -C /usr/local/bin nebi
+# Install nebi: copy from NEBI_IMAGE if provided, else download from GitHub release.
+RUN --mount=from=nebi-source,dst=/nebi-source \
+    if [ -f /nebi-source/app/nebi ]; then \
+        cp /nebi-source/app/nebi /usr/local/bin/nebi; \
+    else \
+        curl -fsSL \
+        "https://github.com/nebari-dev/nebi/releases/download/v${NEBI_VERSION}/nebi_${NEBI_VERSION}_linux_$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "arm64").tar.gz" \
+        | tar -xz -C /usr/local/bin nebi; \
+    fi
 
 COPY nebi/jupyter_server_config.py /usr/local/etc/jupyter/jupyter_server_config.py
 COPY nebi/icons /usr/local/etc/jupyter/icons

--- a/images/nebi/jupyter_server_config.py
+++ b/images/nebi/jupyter_server_config.py
@@ -32,6 +32,10 @@ nebi_remote_url = os.environ.get("NEBI_REMOTE_URL", "")
 if nebi_remote_url:
     nebi_env["NEBI_REMOTE_URL"] = nebi_remote_url
 
+nebi_auth_token = os.environ.get("NEBI_AUTH_TOKEN", "")
+if nebi_auth_token:
+    nebi_env["NEBI_AUTH_TOKEN"] = nebi_auth_token
+
 c.ServerApp.terminado_settings = {"shell_command": ["/bin/bash"]}
 c.ServerApp.kernel_spec_manager_class = "nb_nebi_kernels.NebiKernelSpecManager"
 

--- a/templates/hub-nebi-networkpolicy.yaml
+++ b/templates/hub-nebi-networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.nebi.internalURL .Values.nebi.namespace }}
+# Allows the JupyterHub pod to reach the Nebi server for token exchange
+# at spawn time (pre_spawn_hook calls /api/v1/auth/session).
+# Kubernetes NetworkPolicy is additive — this rule is evaluated alongside
+# the JupyterHub subchart's default network policies.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-hub-nebi-egress
+  labels:
+    {{- include "nebari-data-science-pack.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      component: hub
+      app: jupyterhub
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.nebi.namespace }}
+      ports:
+        - port: 8460
+          protocol: TCP
+{{- end }}

--- a/templates/hub-nebi-networkpolicy.yaml
+++ b/templates/hub-nebi-networkpolicy.yaml
@@ -22,6 +22,6 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Values.nebi.namespace }}
       ports:
-        - port: 8460
+        - port: {{ .Values.nebi.port | default 8460 }}
           protocol: TCP
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -67,9 +67,9 @@ jupyterhub:
   # internal OAuth redirects use the real hostname instead of 0.0.0.0.
   custom:
     external-url: ""
-    nebi-image: ""         # Set from .Values.nebi.image (repository:tag)
-    nebi-remote-url: ""    # Set from .Values.nebi.remoteURL
-    nebi-internal-url: "" # Set from .Values.nebi.internalURL
+    nebi-image: ""         # Deployer must set to repository:tag (e.g., quay.io/nebari/nebi:sha-abc)
+    nebi-remote-url: ""    # Deployer must set to match .Values.nebi.remoteURL
+    nebi-internal-url: ""  # Deployer must set to match .Values.nebi.internalURL
     # Keycloak token exchange config (for Nebi auto-auth at spawn time).
     # The hub client secret is read from JUPYTERHUB_OIDC_CLIENT_SECRET env var
     # (mounted from K8s secret via hub.extraEnv) to avoid plaintext in values.

--- a/values.yaml
+++ b/values.yaml
@@ -42,6 +42,13 @@ sharedStorage:
 # When the nebi-pack is deployed alongside data-science-pack, set remoteURL
 # so that JupyterLab pods auto-connect to the Nebi team server.
 nebi:
+  # Nebi binary image. An init container copies the nebi binary from this image
+  # into each JupyterLab pod, so the version is controlled at deploy time rather
+  # than baked into the jupyterlab image.
+  image:
+    repository: quay.io/nebari/nebi
+    tag: ""  # Required: e.g., sha-a2c937a or pr-199
+    pullPolicy: IfNotPresent
   # URL of the remote Nebi server (e.g., https://nebi.nebari.example.com)
   # When set, the Nebi local instance in each JupyterLab pod will auto-connect
   # to this server using the user's Keycloak IdToken cookie.
@@ -60,6 +67,7 @@ jupyterhub:
   # internal OAuth redirects use the real hostname instead of 0.0.0.0.
   custom:
     external-url: ""
+    nebi-image: ""         # Set from .Values.nebi.image (repository:tag)
     nebi-remote-url: ""    # Set from .Values.nebi.remoteURL
     nebi-internal-url: "" # Set from .Values.nebi.internalURL
     # Keycloak token exchange config (for Nebi auto-auth at spawn time).

--- a/values.yaml
+++ b/values.yaml
@@ -58,6 +58,8 @@ nebi:
   internalURL: ""
   # Namespace where nebi-pack is deployed (enables hub -> nebi network policy).
   namespace: ""
+  # Port the Nebi server listens on (used in hub -> nebi NetworkPolicy egress rule).
+  port: 8460
 
 # JupyterHub configuration
 # All values under this key are passed to the jupyterhub subchart

--- a/values.yaml
+++ b/values.yaml
@@ -70,6 +70,7 @@ jupyterhub:
   custom:
     external-url: ""
     nebi-image: ""         # Deployer must set to repository:tag (e.g., quay.io/nebari/nebi:sha-abc)
+    nebi-image-pull-policy: "IfNotPresent"  # Pull policy for nebi init container
     nebi-remote-url: ""    # Deployer must set to match .Values.nebi.remoteURL
     nebi-internal-url: ""  # Deployer must set to match .Values.nebi.internalURL
     # Keycloak token exchange config (for Nebi auto-auth at spawn time).

--- a/values.yaml
+++ b/values.yaml
@@ -46,6 +46,11 @@ nebi:
   # When set, the Nebi local instance in each JupyterLab pod will auto-connect
   # to this server using the user's Keycloak IdToken cookie.
   remoteURL: ""
+  # Cluster-internal URL for Hub -> Nebi token exchange at spawn time.
+  # Example: http://nebi-pack-nebari-nebi-pack.nebi.svc.cluster.local
+  internalURL: ""
+  # Namespace where nebi-pack is deployed (enables hub -> nebi network policy).
+  namespace: ""
 
 # JupyterHub configuration
 # All values under this key are passed to the jupyterhub subchart
@@ -55,7 +60,8 @@ jupyterhub:
   # internal OAuth redirects use the real hostname instead of 0.0.0.0.
   custom:
     external-url: ""
-    nebi-remote-url: ""  # Set by templates from .Values.nebi.remoteURL
+    nebi-remote-url: ""   # Set from .Values.nebi.remoteURL
+    nebi-internal-url: "" # Set from .Values.nebi.internalURL
     # jhub-apps (JAppsConfig) overrides.
     # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
     # See https://jhub-apps.nebari.dev/docs/configuration for available options.

--- a/values.yaml
+++ b/values.yaml
@@ -60,8 +60,13 @@ jupyterhub:
   # internal OAuth redirects use the real hostname instead of 0.0.0.0.
   custom:
     external-url: ""
-    nebi-remote-url: ""   # Set from .Values.nebi.remoteURL
+    nebi-remote-url: ""    # Set from .Values.nebi.remoteURL
     nebi-internal-url: "" # Set from .Values.nebi.internalURL
+    # Keycloak token exchange config (for Nebi auto-auth at spawn time)
+    keycloak-token-url: ""       # e.g., http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token
+    nebi-client-id: ""           # Nebi's Keycloak OIDC client ID
+    jupyterhub-client-id: ""     # JupyterHub's Keycloak OIDC client ID
+    jupyterhub-client-secret: "" # JupyterHub's Keycloak OIDC client secret
     # jhub-apps (JAppsConfig) overrides.
     # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
     # See https://jhub-apps.nebari.dev/docs/configuration for available options.

--- a/values.yaml
+++ b/values.yaml
@@ -62,11 +62,12 @@ jupyterhub:
     external-url: ""
     nebi-remote-url: ""    # Set from .Values.nebi.remoteURL
     nebi-internal-url: "" # Set from .Values.nebi.internalURL
-    # Keycloak token exchange config (for Nebi auto-auth at spawn time)
-    keycloak-token-url: ""       # e.g., http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token
-    nebi-client-id: ""           # Nebi's Keycloak OIDC client ID
-    jupyterhub-client-id: ""     # JupyterHub's Keycloak OIDC client ID
-    jupyterhub-client-secret: "" # JupyterHub's Keycloak OIDC client secret
+    # Keycloak token exchange config (for Nebi auto-auth at spawn time).
+    # The hub client secret is read from JUPYTERHUB_OIDC_CLIENT_SECRET env var
+    # (mounted from K8s secret via hub.extraEnv) to avoid plaintext in values.
+    keycloak-token-url: ""   # e.g., http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token
+    nebi-client-id: ""       # Nebi's Keycloak OIDC client ID
+    jupyterhub-client-id: "" # JupyterHub's Keycloak OIDC client ID
     # jhub-apps (JAppsConfig) overrides.
     # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
     # See https://jhub-apps.nebari.dev/docs/configuration for available options.


### PR DESCRIPTION
## Summary

- Store raw Keycloak IdToken in JupyterHub `auth_state` so it's available to the spawner
- Add `pre_spawn_hook` that exchanges the IdToken for a Nebi JWT via the Nebi server's `/api/v1/auth/session` endpoint (cluster-internal call)
- Inject `NEBI_AUTH_TOKEN` env var into singleuser pods + pass it through to the `nebi serve` subprocess
- Add `nebi.internalURL` and `nebi.namespace` chart values for configuring the integration
- Add conditional `NetworkPolicy` allowing hub -> nebi egress (only created when nebi values are set)

All nebi integration is no-op when `nebi.internalURL` is not configured — no behavior change for deployments without Nebi.

Closes https://github.com/nebari-dev/nebari-nebi-pack/issues/4