### PR TITLE
Fix hardcoded ConfigMap name in extraVolumes

### DIFF
--- a/templates/hub-config.yaml
+++ b/templates/hub-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-hub-config
+  name: {{ include "nebari-data-science-pack.name" . }}-hub-config
   labels:
     {{- include "nebari-data-science-pack.labels" . | nindent 4 }}
 data:

--- a/values.yaml
+++ b/values.yaml
@@ -110,7 +110,7 @@ jupyterhub:
     extraVolumes:
       - name: custom-config
         configMap:
-          name: data-science-pack-hub-config
+          name: nebari-data-science-pack-hub-config
 
     extraVolumeMounts:
       - name: custom-config


### PR DESCRIPTION
## Summary
- Use the chart name helper (`{{ include "nebari-data-science-pack.name" . }}`) in `hub-config.yaml` instead of `{{ .Release.Name }}` to make the ConfigMap name deterministic
- Update `values.yaml` to reference `nebari-data-science-pack-hub-config` to match

This fixes a bug where the hub pod fails with `configmap "data-science-pack-hub-config" not found` when the Helm release name is anything other than `data-science-pack` (e.g., when installed via NIC as `nebari-data-science-pack`).

## Test plan
- [ ] `helm template test . --set nebariapp.hostname=test.example.com` renders matching ConfigMap name in both the ConfigMap resource and the hub deployment extraVolumes
- [ ] `helm install nebari-data-science-pack . --set nebariapp.hostname=test.example.com` — hub pod starts successfully

Fixes #19