### PR TITLE
fix: redirect JupyterHub logout to Envoy Gateway OIDC logout path

### DIFF
--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -95,3 +95,7 @@ if get_config("custom.external-url", ""):
     # All users who pass Keycloak auth at the gateway are allowed
     c.Authenticator.allow_all = True
     c.Authenticator.enable_auth_state = True
+    # Redirect logout to Envoy Gateway's OIDC logout path, which clears
+    # the IdToken/AccessToken/RefreshToken cookies and terminates the
+    # Keycloak session via the end_session_endpoint.
+    c.JupyterHub.logout_redirect_url = "/logout"


### PR DESCRIPTION
## Summary

- Redirect JupyterHub logout to Envoy Gateway's `/logout` path so the full OIDC logout chain executes (clear Envoy cookies → terminate Keycloak session)
- Previously, logout only cleared the JupyterHub session cookie while Envoy's IdToken/AccessToken/RefreshToken cookies persisted, causing immediate re-authentication

Closes #21