### PR TITLE
fix: use Envoy Gateway default OIDC callback path

### DIFF
--- a/templates/nebariapp.yaml
+++ b/templates/nebariapp.yaml
@@ -20,7 +20,7 @@ spec:
     enabled: {{ .enabled | default true }}
     provider: {{ .provider | default "keycloak" }}
     provisionClient: {{ .provisionClient | default true }}
-    redirectURI: {{ .redirectURI | default "/hub/oauth_callback" }}
+    redirectURI: {{ .redirectURI | default "/oauth2/callback" }}
     {{- with .scopes }}
     scopes:
       {{- toYaml . | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ nebariapp:
     enabled: true
     provider: keycloak
     provisionClient: true
-    redirectURI: /hub/oauth_callback  # JupyterHub's OAuth callback
+    redirectURI: /oauth2/callback  # Envoy Gateway's default OIDC callback
     scopes:
       - openid
       - profile


### PR DESCRIPTION
## Summary

- Change `redirectURI` from `/hub/oauth_callback` to `/oauth2/callback` in the NebariApp auth config
- `/hub/oauth_callback` sits inside JupyterHub's route space (`/hub/*`), causing "OAuth flow failed" errors when the callback request conflicts with JupyterHub's routing
- `/oauth2/callback` is Envoy Gateway's default OIDC callback path and sits outside JupyterHub's routes

## Context

The data-science-pack uses gateway-level auth (`EnvoyOIDCAuthenticator` reads cookies set by Envoy Gateway). JupyterHub never processes the OAuth callback itself — Envoy handles the entire code exchange, sets cookies, and redirects the browser to the original URL stored in the `state` parameter. The callback path has no effect on where the user lands after login.

Using `/hub/oauth_callback` placed the callback inside JupyterHub's route space, where the request could conflict with JupyterHub's routing and produce an "OAuth flow failed" error page.

Related: #21

## Test plan

- [ ] Deploy and verify login flow completes without "OAuth flow failed" error
- [ ] Verify user lands at the hub home page after Keycloak authentication
- [ ] Verify logout still works (unrelated but confirm no regression)