### PR TITLE
Add nebi environment listing for jhub-apps selector

### DIFF
--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -34,27 +34,20 @@ class EnvoyOIDCAuthenticator(Authenticator):
 
     auto_login = True
 
+    # Re-read cookies every 60s so auth_state stays fresh.
+    # Envoy Gateway refreshes the AccessToken cookie automatically;
+    # this ensures JupyterHub's stored auth_state keeps up.
+    auth_refresh_age = 60
+
     def get_handlers(self, app):
         return [("/logout", EnvoyOIDCLogoutHandler)]
 
-    async def authenticate(self, handler, data=None):
-        # Envoy Gateway stores two tokens as cookies after OIDC authentication:
-        #
-        # IdToken (IdToken-<suffix>):
-        #   JWT containing user identity claims (sub, email, groups, etc.).
-        #   The `aud` claim is set to THIS client (JupyterHub's Keycloak client).
-        #   Used here to extract the username and groups.
-        #
-        # AccessToken (AccessToken-<suffix>):
-        #   Credential for accessing resources. Can be exchanged at Keycloak's
-        #   token endpoint (RFC 8693) for a token with a different audience —
-        #   e.g., exchanging a JupyterHub access token for a Nebi ID token.
-        #   Stored in auth_state for the spawner's pre_spawn_hook to use.
-        #
-        # RefreshToken (RefreshToken-<suffix>):
-        #   Long-lived token for obtaining fresh access tokens. Access tokens
-        #   expire in minutes, so the pre_spawn_hook uses the refresh token
-        #   to get a fresh access token before doing the exchange.
+    @staticmethod
+    def _extract_envoy_cookies(handler):
+        """Extract Envoy Gateway OIDC cookies from the request.
+
+        Returns (id_token, access_token, refresh_token) — any may be None.
+        """
         id_token = None
         access_token = None
         refresh_token = None
@@ -65,6 +58,25 @@ class EnvoyOIDCAuthenticator(Authenticator):
                 access_token = value.value
             elif name.startswith("RefreshToken"):
                 refresh_token = value.value
+        return id_token, access_token, refresh_token
+
+    async def authenticate(self, handler, data=None):
+        # Envoy Gateway stores tokens as cookies after OIDC authentication:
+        #
+        # IdToken (IdToken-<suffix>):
+        #   JWT with user identity claims (sub, email, groups).
+        #   Used here to extract the username and groups.
+        #
+        # AccessToken (AccessToken-<suffix>):
+        #   Short-lived credential (~5 min). Can be exchanged at Keycloak
+        #   for a token with a different audience (RFC 8693).
+        #   Stored in auth_state for the spawner and nebi env listing.
+        #
+        # RefreshToken (RefreshToken-<suffix>):
+        #   Envoy manages this internally (refreshToken: true in SecurityPolicy).
+        #   NOT forwarded to upstream — the cookie is typically absent here.
+        #   Envoy uses it to refresh the AccessToken cookie transparently.
+        id_token, access_token, refresh_token = self._extract_envoy_cookies(handler)
 
         if not id_token:
             self.log.warning("No IdToken cookie found")
@@ -105,6 +117,37 @@ class EnvoyOIDCAuthenticator(Authenticator):
                 }.items() if v is not None
             },
         }
+
+    async def refresh_user(self, user, handler=None):
+        """Re-read Envoy's OIDC cookies to keep auth_state fresh.
+
+        Envoy Gateway automatically refreshes the AccessToken cookie using
+        its internally managed refresh token.  By reading the fresh cookie
+        here, we update auth_state so downstream consumers (nebi token
+        exchange, spawner hooks) always have a valid access token.
+
+        Called by JupyterHub every `auth_refresh_age` seconds (60s).
+        """
+        if handler is None:
+            # No request context (e.g. internal API call) — can't read cookies
+            return True
+
+        id_token, access_token, refresh_token = self._extract_envoy_cookies(handler)
+
+        if not id_token:
+            # Cookies missing — session may have expired, force re-login
+            self.log.warning("refresh_user: no IdToken cookie for %s, invalidating session", user.name)
+            return False
+
+        auth_state = {
+            k: v for k, v in {
+                "id_token": id_token,
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            }.items() if v is not None
+        }
+
+        return {"name": user.name, "auth_state": auth_state}
 
 
 if get_config("custom.external-url", ""):

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -302,6 +302,35 @@ async def _nebi_pre_spawn_hook(spawner):
 
         spawner.environment = {**spawner.environment, "NEBI_AUTH_TOKEN": nebi_jwt}
         log.info("Nebi auto-auth succeeded for %s", spawner.user.name)
+
+        # If a nebi workspace is selected (via jhub-apps environment selector),
+        # add an init container to pull it before the app starts.
+        conda_env = getattr(spawner, "user_options", {}).get("conda_env", "")
+        if conda_env:
+            # conda_env may be "owner/workspace-name" or just "workspace-name"
+            workspace_name = conda_env.rsplit("/", 1)[-1] if "/" in conda_env else conda_env
+            nebi_remote = get_config("custom.nebi-remote-url", "")
+            log.info(
+                "Adding nebi-pull init container for workspace %s (user %s)",
+                workspace_name, spawner.user.name,
+            )
+            spawner.init_containers = list(spawner.init_containers) + [{
+                "name": "nebi-pull",
+                "image": spawner.image,
+                "command": [
+                    "/bin/sh", "-c",
+                    f"nebi pull {workspace_name} --force || "
+                    f"echo 'WARNING: nebi pull {workspace_name} failed (app will start without workspace)'",
+                ],
+                "env": [
+                    {"name": "NEBI_AUTH_TOKEN", "value": nebi_jwt},
+                    {"name": "NEBI_REMOTE_URL", "value": nebi_remote},
+                ],
+                "volumeMounts": [
+                    {"name": "nebi-bin", "mountPath": "/usr/local/bin/nebi", "subPath": "nebi"},
+                    {"name": "home", "mountPath": "/home/jovyan"},
+                ],
+            }]
     except Exception:
         log.exception("Nebi auto-auth failed for %s (pod will still spawn)", spawner.user.name)
 

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -323,6 +323,7 @@ async def _nebi_pre_spawn_hook(spawner):
                     f"echo 'WARNING: nebi pull {workspace_name} failed (app will start without workspace)'",
                 ],
                 "env": [
+                    {"name": "HOME", "value": "/home/jovyan"},
                     {"name": "NEBI_AUTH_TOKEN", "value": nebi_jwt},
                     {"name": "NEBI_REMOTE_URL", "value": nebi_remote},
                 ],

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -1,12 +1,15 @@
 """KubeSpawner configuration."""
 # ruff: noqa: F821 - `c` is a magic global provided by JupyterHub
 
+import asyncio
 import json
 import logging
 import os
+import urllib.error
+import urllib.request
 from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from z2jh import get_config
 
 log = logging.getLogger(__name__)
@@ -91,57 +94,67 @@ c.KubeSpawner.environment = env
 
 
 # ---------------------------------------------------------------------------
-# Nebi auto-authentication (Keycloak token exchange, RFC 8693)
+# Keycloak token exchange helpers (synchronous, shared)
 # ---------------------------------------------------------------------------
-# At spawn time, exchange the user's JupyterHub access token for a
-# Nebi-audience ID token via Keycloak, then convert that into a Nebi JWT.
+# These synchronous functions are the single implementation of the 3-step
+# Keycloak → Nebi token exchange.  They are used by:
+#   - _nebi_pre_spawn_hook (below) via asyncio.to_thread()
+#   - 03-nebi-envs.py directly (jhub-apps calls conda_envs synchronously)
 #
-# Why token exchange? The IdToken in auth_state has aud=jupyterhub-client,
-# but Nebi's session endpoint only accepts tokens with aud=nebi-client.
-# Token exchange lets Keycloak issue a new ID token for the correct audience.
+# Using urllib.request (not Tornado AsyncHTTPClient) so the same code works
+# in both sync and async contexts.
 
 
-async def _refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_client_secret):
+def _extract_error_body(exc):
+    """Extract HTTP response body from an exception for diagnostic logging.
+
+    urllib.error.HTTPError exposes the body via .read(); other exceptions
+    do not.  Returns an empty string if the body cannot be read.
+    """
+    if hasattr(exc, "read"):
+        try:
+            return exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            pass
+    return ""
+
+
+def _sync_refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_client_secret):
     """Use the refresh token to get a fresh access token from Keycloak.
 
-    Access tokens expire in minutes. The refresh token (stored in auth_state
-    from Envoy's RefreshToken cookie) has a much longer lifetime and can be
-    used to obtain a fresh access token without user interaction.
-
-    Returns the new access token string, or None on failure.
+    Returns the new access token string, or empty string on failure.
     """
     body = urlencode({
         "grant_type": "refresh_token",
         "refresh_token": refresh_token,
         "client_id": hub_client_id,
         "client_secret": hub_client_secret,
-    })
+    }).encode("utf-8")
+    req = Request(
+        keycloak_url,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
     try:
-        resp = await AsyncHTTPClient().fetch(HTTPRequest(
-            keycloak_url,
-            method="POST",
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            body=body,
-            request_timeout=10,
-        ))
+        with urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            return data.get("access_token", "")
     except Exception as exc:
-        resp_body = getattr(exc, "response", None)
-        if resp_body is not None:
-            resp_body = resp_body.body.decode() if resp_body.body else ""
-        log.error("Keycloak token refresh error: %s response=%s", exc, resp_body)
-        raise
-    return json.loads(resp.body).get("access_token", "")
+        resp_body = _extract_error_body(exc)
+        log.error(
+            "Keycloak token refresh failed: %s response=%s (url=%s, client_id=%s)",
+            exc, resp_body, keycloak_url, hub_client_id,
+        )
+        return ""
 
 
-async def _exchange_access_token_for_nebi_id_token(
+def _sync_exchange_access_token_for_nebi_id_token(
     access_token, keycloak_url, nebi_client_id, hub_client_id, hub_client_secret,
 ):
     """Exchange a JupyterHub access token for a Nebi-audience ID token via Keycloak.
 
-    The access token proves the user is authenticated. Keycloak validates it
-    and issues a new ID token with aud=nebi-client-id.
-
-    Returns the Nebi ID token string, or None on failure.
+    Returns the Nebi ID token string, or empty string on failure.
     """
     body = urlencode({
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
@@ -150,50 +163,101 @@ async def _exchange_access_token_for_nebi_id_token(
         "audience": nebi_client_id,
         "client_id": hub_client_id,
         "client_secret": hub_client_secret,
-    })
+    }).encode("utf-8")
+    req = Request(
+        keycloak_url,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
     try:
-        resp = await AsyncHTTPClient().fetch(HTTPRequest(
-            keycloak_url,
-            method="POST",
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            body=body,
-            request_timeout=10,
-        ))
+        with urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            # Prefer id_token if present (has user identity claims), fall back to access_token
+            return data.get("id_token") or data.get("access_token", "")
     except Exception as exc:
-        resp_body = getattr(exc, "response", None)
-        if resp_body is not None:
-            resp_body = resp_body.body.decode() if resp_body.body else ""
-        log.error("Keycloak token exchange error: %s response=%s", exc, resp_body)
-        raise
-    data = json.loads(resp.body)
-    # Prefer id_token if present (has user identity claims), fall back to access_token
-    return data.get("id_token") or data.get("access_token", "")
+        resp_body = _extract_error_body(exc)
+        log.error(
+            "Keycloak token exchange failed: %s response=%s (url=%s, audience=%s, client_id=%s)",
+            exc, resp_body, keycloak_url, nebi_client_id, hub_client_id,
+        )
+        return ""
 
 
-async def _exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Prevent urllib from following redirects (matches Tornado follow_redirects=False)."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(newurl, code, msg, headers, fp)
+
+
+def _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
     """Exchange a Nebi-audience ID token for a Nebi JWT via the session endpoint.
 
-    Nebi verifies the ID token (aud must match nebi-client-id), finds/creates
-    the user, syncs roles from groups, and returns a Nebi JWT (24h expiry).
-
-    Returns the Nebi JWT string, or None on failure.
+    Uses a no-redirect opener so auth failures surface as errors instead of
+    silently following a redirect to a login page.
+    Returns the Nebi JWT string, or empty string on failure.
     """
     session_url = f"{nebi_internal_url.rstrip('/')}/api/v1/auth/session"
-    resp = await AsyncHTTPClient().fetch(HTTPRequest(
+    req = Request(
         session_url,
-        method="GET",
         headers={"Cookie": f"IdToken={nebi_id_token}"},
-        request_timeout=10,
-        follow_redirects=False,
-    ))
-    return json.loads(resp.body).get("token", "")
+        method="GET",
+    )
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    try:
+        with opener.open(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            return data.get("token", "")
+    except Exception as exc:
+        resp_body = _extract_error_body(exc)
+        log.error(
+            "Nebi session exchange failed: %s response=%s (url=%s)",
+            exc, resp_body, session_url,
+        )
+        return ""
+
+
+def get_nebi_jwt(refresh_token, access_token, keycloak_url, nebi_cid, hub_cid, hub_secret, nebi_url):
+    """Run the full 3-step token exchange and return a Nebi JWT.
+
+    This is a synchronous, self-contained helper used by both the spawner hook
+    (via asyncio.to_thread) and the jhub-apps environment listing callable
+    (03-nebi-envs.py).
+
+    Returns the Nebi JWT string, or empty string on any failure.
+    """
+    # Step 1: Refresh the access token (preferred) or use the existing one
+    if refresh_token:
+        access_token = _sync_refresh_access_token(
+            refresh_token, keycloak_url, hub_cid, hub_secret,
+        )
+        if not access_token:
+            return ""
+    if not access_token:
+        return ""
+
+    # Step 2: Exchange access token for Nebi-audience ID token
+    nebi_id_token = _sync_exchange_access_token_for_nebi_id_token(
+        access_token, keycloak_url, nebi_cid, hub_cid, hub_secret,
+    )
+    if not nebi_id_token:
+        return ""
+
+    # Step 3: Exchange Nebi ID token for Nebi JWT
+    return _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_url)
+
+
+# ---------------------------------------------------------------------------
+# Nebi auto-authentication (pre-spawn hook)
+# ---------------------------------------------------------------------------
 
 
 async def _nebi_pre_spawn_hook(spawner):
     """Authenticate the user with the remote Nebi server at spawn time.
 
-    Reads the Keycloak access token from auth_state, exchanges it for a
-    Nebi JWT, and injects it as NEBI_AUTH_TOKEN into the pod environment.
+    Exchanges the user's Keycloak token for a Nebi JWT and injects it as
+    NEBI_AUTH_TOKEN into the pod environment.
     Non-fatal: if any step fails, the pod still spawns without auto-auth.
     """
     # Tell jhub-app-proxy to use pixi activation (instead of conda) for app pods.
@@ -210,7 +274,6 @@ async def _nebi_pre_spawn_hook(spawner):
     keycloak_url = get_config("custom.keycloak-token-url", "")
     nebi_cid = get_config("custom.nebi-client-id", "")
     hub_cid = get_config("custom.jupyterhub-client-id", "")
-    # Read from env var (mounted from K8s secret) to avoid plaintext in Helm values.
     hub_secret = os.environ.get("JUPYTERHUB_OIDC_CLIENT_SECRET", "")
     nebi_url = get_config("custom.nebi-internal-url", "")
 
@@ -219,31 +282,22 @@ async def _nebi_pre_spawn_hook(spawner):
         return
 
     try:
-        # Refresh the access token first — it expires in minutes, but the
-        # refresh token (from Envoy's RefreshToken cookie) lasts much longer.
-        access_token = auth_state.get("access_token") or ""
         refresh_token = auth_state.get("refresh_token")
-        if refresh_token:
-            access_token = await _refresh_access_token(
-                refresh_token, keycloak_url, hub_cid, hub_secret,
-            )
-            if not access_token:
-                log.warning("Token refresh returned no access token for %s", spawner.user.name)
-                return
-        elif not access_token:
+        access_token = auth_state.get("access_token") or ""
+
+        if not refresh_token and not access_token:
             log.warning("No access_token or refresh_token for %s, skipping", spawner.user.name)
             return
 
-        nebi_id_token = await _exchange_access_token_for_nebi_id_token(
-            access_token, keycloak_url, nebi_cid, hub_cid, hub_secret,
+        # Run the synchronous token exchange in a thread to avoid blocking
+        # the Tornado event loop.
+        nebi_jwt = await asyncio.to_thread(
+            get_nebi_jwt,
+            refresh_token, access_token,
+            keycloak_url, nebi_cid, hub_cid, hub_secret, nebi_url,
         )
-        if not nebi_id_token:
-            log.warning("Keycloak token exchange returned no token for %s", spawner.user.name)
-            return
-
-        nebi_jwt = await _exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_url)
         if not nebi_jwt:
-            log.warning("Nebi session returned no token for %s", spawner.user.name)
+            log.warning("Nebi token exchange returned no JWT for %s", spawner.user.name)
             return
 
         spawner.environment = {**spawner.environment, "NEBI_AUTH_TOKEN": nebi_jwt}

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -48,6 +48,31 @@ c.KubeSpawner.volume_mounts = [
 c.KubeSpawner.notebook_dir = "/home/jovyan"
 c.KubeSpawner.working_dir = "/home/jovyan"
 
+# Co-locate all pods for the same user on the same node.
+# hcloud-volumes is ReadWriteOnce — only one node can mount it at a time.
+# Pod affinity ensures jhub-apps app pods land on the same node as the
+# user's JupyterLab pod so the shared home PVC can be mounted by all of them.
+c.KubeSpawner.extra_pod_config = {
+    "affinity": {
+        "podAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "labelSelector": {
+                        "matchExpressions": [
+                            {
+                                "key": "hub.jupyter.org/username",
+                                "operator": "In",
+                                "values": ["{username}"],
+                            }
+                        ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname",
+                }
+            ]
+        }
+    }
+}
+
 
 # ---------------------------------------------------------------------------
 # Nebi binary (init container)

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -329,6 +329,32 @@ def get_nebi_jwt(refresh_token, access_token, keycloak_url, nebi_cid, hub_cid, h
     return nebi_jwt
 
 
+def _fetch_fresh_auth_state(username):
+    """Fetch the latest auth_state for a user via the JupyterHub API.
+
+    Uses JUPYTERHUB_API_TOKEN (which has admin:auth_state scope) to read
+    the user's auth_state, which refresh_user() keeps updated with fresh
+    Envoy cookies on browser requests.
+
+    Returns the auth_state dict, or None on failure.
+    """
+    api_url = os.environ.get("JUPYTERHUB_API_URL", "")
+    api_token = os.environ.get("JUPYTERHUB_API_TOKEN", "")
+    if not api_url or not api_token:
+        log.warning("JUPYTERHUB_API_URL/TOKEN not set, cannot fetch fresh auth_state")
+        return None
+    try:
+        req = Request(
+            f"{api_url}/users/{username}",
+            headers={"Authorization": f"token {api_token}"},
+        )
+        with urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read()).get("auth_state")
+    except Exception as exc:
+        log.error("Failed to fetch fresh auth_state for %s: %s", username, exc)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Nebi auto-authentication (pre-spawn hook)
 # ---------------------------------------------------------------------------
@@ -365,6 +391,26 @@ async def _nebi_pre_spawn_hook(spawner):
     try:
         refresh_token = auth_state.get("refresh_token")
         access_token = auth_state.get("access_token") or ""
+
+        # The access token from auth_state may be stale (refresh_user updates
+        # it on browser requests, but the spawn is an internal API call).
+        # Check expiry and re-fetch from the hub API if needed.
+        if access_token and not refresh_token:
+            claims = _decode_jwt_claims(access_token)
+            import time as _time
+            exp = claims.get("exp", 0)
+            remaining = exp - int(_time.time()) if exp else 0
+            if remaining < 30:
+                log.info(
+                    "Access token for %s expires in %ds, fetching fresh auth_state from hub API",
+                    spawner.user.name, remaining,
+                )
+                fresh_state = await asyncio.to_thread(
+                    _fetch_fresh_auth_state, spawner.user.name,
+                )
+                if fresh_state:
+                    access_token = fresh_state.get("access_token") or access_token
+                    refresh_token = fresh_state.get("refresh_token") or refresh_token
 
         if not refresh_token and not access_token:
             log.warning("No access_token or refresh_token for %s, skipping", spawner.user.name)

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -447,8 +447,11 @@ async def _nebi_pre_spawn_hook(spawner):
                 "workingDir": "/home/jovyan",
                 "command": [
                     "/bin/sh", "-c",
-                    f"nebi pull {workspace_name} --force || "
-                    f"echo 'WARNING: nebi pull {workspace_name} failed (app will start without workspace)'",
+                    # Pull workspace files, then pre-install the pixi environment
+                    # so jhub-app-proxy's `pixi run` doesn't hit the install timeout.
+                    f"nebi pull {workspace_name} --force && "
+                    f"pixi install || "
+                    f"echo 'WARNING: nebi pull or pixi install failed for {workspace_name}'",
                 ],
                 "env": [
                     {"name": "HOME", "value": "/home/jovyan"},

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -431,36 +431,59 @@ async def _nebi_pre_spawn_hook(spawner):
         log.info("Nebi auto-auth succeeded for %s", spawner.user.name)
 
         # If a nebi workspace is selected (via jhub-apps environment selector),
-        # add an init container to pull it before the app starts.
+        # add an init container to pull it into an ephemeral volume.
+        # Each app pod gets its own emptyDir at /tmp/nebi-env so multiple apps
+        # don't overwrite each other's workspace files on the shared user PVC.
         conda_env = getattr(spawner, "user_options", {}).get("conda_env", "")
         if conda_env:
-            # conda_env may be "owner/workspace-name" or just "workspace-name"
             workspace_name = conda_env.rsplit("/", 1)[-1] if "/" in conda_env else conda_env
             nebi_remote = get_config("custom.nebi-remote-url", "")
+            nebi_env_dir = "/tmp/nebi-env"
+            ws_dir = f"{nebi_env_dir}/workspace"
             log.info(
                 "Adding nebi-pull init container for workspace %s (user %s)",
                 workspace_name, spawner.user.name,
             )
+
+            # Add ephemeral volume for this pod's workspace files + nebi DB
+            spawner.volumes = list(spawner.volumes) + [{
+                "name": "nebi-env",
+                "emptyDir": {},
+            }]
+            # Mount in main container so nebi workspace list + pixi run can find it
+            spawner.volume_mounts = list(spawner.volume_mounts) + [{
+                "name": "nebi-env",
+                "mountPath": nebi_env_dir,
+            }]
+            # Tell nebi in the main container to use the ephemeral DB
+            spawner.environment = {
+                **spawner.environment,
+                "NEBI_DATA_DIR": nebi_env_dir,
+            }
+
             spawner.init_containers = list(spawner.init_containers) + [{
                 "name": "nebi-pull",
                 "image": spawner.image,
-                "workingDir": "/home/jovyan",
+                "workingDir": ws_dir,
                 "command": [
                     "/bin/sh", "-c",
-                    # Pull workspace files, then pre-install the pixi environment
-                    # so jhub-app-proxy's `pixi run` doesn't hit the install timeout.
-                    f"nebi pull {workspace_name} --force && "
-                    f"pixi install || "
+                    # Pull workspace files into the ephemeral dir, then
+                    # pre-install the pixi environment so jhub-app-proxy's
+                    # `pixi run` doesn't hit the ready-check timeout.
+                    f"mkdir -p {ws_dir} && "
+                    f"nebi pull {workspace_name} -o {ws_dir} --force && "
+                    f"pixi install --manifest-path {ws_dir}/pixi.toml || "
                     f"echo 'WARNING: nebi pull or pixi install failed for {workspace_name}'",
                 ],
                 "env": [
-                    {"name": "HOME", "value": "/home/jovyan"},
+                    {"name": "HOME", "value": nebi_env_dir},
+                    {"name": "NEBI_DATA_DIR", "value": nebi_env_dir},
                     {"name": "NEBI_AUTH_TOKEN", "value": nebi_jwt},
                     {"name": "NEBI_REMOTE_URL", "value": nebi_remote},
                 ],
                 "volumeMounts": [
                     {"name": "nebi-bin", "mountPath": "/usr/local/bin/nebi", "subPath": "nebi"},
-                    {"name": "home", "mountPath": "/home/jovyan"},
+                    {"name": "nebi-env", "mountPath": nebi_env_dir},
                 ],
             }]
     except Exception:

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -119,11 +119,55 @@ def _extract_error_body(exc):
     return ""
 
 
+def _decode_jwt_claims(token):
+    """Decode JWT payload without verification, for diagnostic logging only.
+
+    Returns a dict of claims or {} if the token is not a valid JWT.
+    """
+    import base64
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    try:
+        payload = parts[1]
+        # Add padding
+        payload += "=" * (4 - len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload))
+    except Exception:
+        return {}
+
+
+def _log_token_diagnostics(label, token):
+    """Log JWT claims relevant to token exchange debugging."""
+    claims = _decode_jwt_claims(token)
+    if not claims:
+        log.warning(
+            "token-exchange: %s token is not a JWT (opaque token, len=%d)",
+            label, len(token),
+        )
+        return
+    import time
+    exp = claims.get("exp", 0)
+    now = int(time.time())
+    log.info(
+        "token-exchange: %s token — iss=%s, aud=%s, azp=%s, exp=%s (%s), sub=%s, scope=%s",
+        label,
+        claims.get("iss", "<missing>"),
+        claims.get("aud", "<missing>"),
+        claims.get("azp", "<missing>"),
+        exp,
+        "EXPIRED" if exp and exp < now else f"valid for {exp - now}s",
+        claims.get("sub", "<missing>"),
+        claims.get("scope", "<missing>"),
+    )
+
+
 def _sync_refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_client_secret):
     """Use the refresh token to get a fresh access token from Keycloak.
 
     Returns the new access token string, or empty string on failure.
     """
+    log.info("token-exchange step 1: refreshing access token (url=%s, client_id=%s)", keycloak_url, hub_client_id)
     body = urlencode({
         "grant_type": "refresh_token",
         "refresh_token": refresh_token,
@@ -139,11 +183,17 @@ def _sync_refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_c
     try:
         with urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
-            return data.get("access_token", "")
+            token = data.get("access_token", "")
+            if token:
+                log.info("token-exchange step 1: refresh succeeded")
+                _log_token_diagnostics("refreshed access", token)
+            else:
+                log.error("token-exchange step 1: refresh response had no access_token (keys: %s)", list(data.keys()))
+            return token
     except Exception as exc:
         resp_body = _extract_error_body(exc)
         log.error(
-            "Keycloak token refresh failed: %s response=%s (url=%s, client_id=%s)",
+            "token-exchange step 1 FAILED: %s response=%s (url=%s, client_id=%s)",
             exc, resp_body, keycloak_url, hub_client_id,
         )
         return ""
@@ -156,6 +206,11 @@ def _sync_exchange_access_token_for_nebi_id_token(
 
     Returns the Nebi ID token string, or empty string on failure.
     """
+    log.info(
+        "token-exchange step 2: exchanging access token for nebi ID token "
+        "(url=%s, audience=%s, client_id=%s)",
+        keycloak_url, nebi_client_id, hub_client_id,
+    )
     body = urlencode({
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
         "subject_token": access_token,
@@ -174,11 +229,17 @@ def _sync_exchange_access_token_for_nebi_id_token(
         with urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
             # Prefer id_token if present (has user identity claims), fall back to access_token
-            return data.get("id_token") or data.get("access_token", "")
+            token = data.get("id_token") or data.get("access_token", "")
+            if token:
+                log.info("token-exchange step 2: exchange succeeded (got %s)", "id_token" if data.get("id_token") else "access_token")
+                _log_token_diagnostics("exchanged nebi", token)
+            else:
+                log.error("token-exchange step 2: exchange response had no id_token or access_token (keys: %s)", list(data.keys()))
+            return token
     except Exception as exc:
         resp_body = _extract_error_body(exc)
         log.error(
-            "Keycloak token exchange failed: %s response=%s (url=%s, audience=%s, client_id=%s)",
+            "token-exchange step 2 FAILED: %s response=%s (url=%s, audience=%s, client_id=%s)",
             exc, resp_body, keycloak_url, nebi_client_id, hub_client_id,
         )
         return ""
@@ -199,6 +260,7 @@ def _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
     Returns the Nebi JWT string, or empty string on failure.
     """
     session_url = f"{nebi_internal_url.rstrip('/')}/api/v1/auth/session"
+    log.info("token-exchange step 3: exchanging nebi ID token for JWT (url=%s)", session_url)
     req = Request(
         session_url,
         headers={"Cookie": f"IdToken={nebi_id_token}"},
@@ -208,11 +270,16 @@ def _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
     try:
         with opener.open(req, timeout=10) as resp:
             data = json.loads(resp.read())
-            return data.get("token", "")
+            token = data.get("token", "")
+            if token:
+                log.info("token-exchange step 3: nebi JWT obtained (len=%d)", len(token))
+            else:
+                log.error("token-exchange step 3: nebi session response had no 'token' key (keys: %s)", list(data.keys()))
+            return token
     except Exception as exc:
         resp_body = _extract_error_body(exc)
         log.error(
-            "Nebi session exchange failed: %s response=%s (url=%s)",
+            "token-exchange step 3 FAILED: %s response=%s (url=%s)",
             exc, resp_body, session_url,
         )
         return ""
@@ -227,14 +294,21 @@ def get_nebi_jwt(refresh_token, access_token, keycloak_url, nebi_cid, hub_cid, h
 
     Returns the Nebi JWT string, or empty string on any failure.
     """
+    log.info("token-exchange: starting 3-step exchange (keycloak=%s, nebi=%s)", keycloak_url, nebi_url)
+
     # Step 1: Refresh the access token (preferred) or use the existing one
     if refresh_token:
         access_token = _sync_refresh_access_token(
             refresh_token, keycloak_url, hub_cid, hub_secret,
         )
         if not access_token:
+            log.error("token-exchange: aborting — step 1 (refresh) returned no token")
             return ""
-    if not access_token:
+    elif access_token:
+        log.info("token-exchange: no refresh_token, using existing access_token")
+        _log_token_diagnostics("existing access", access_token)
+    else:
+        log.error("token-exchange: aborting — no refresh_token and no access_token")
         return ""
 
     # Step 2: Exchange access token for Nebi-audience ID token
@@ -242,10 +316,17 @@ def get_nebi_jwt(refresh_token, access_token, keycloak_url, nebi_cid, hub_cid, h
         access_token, keycloak_url, nebi_cid, hub_cid, hub_secret,
     )
     if not nebi_id_token:
+        log.error("token-exchange: aborting — step 2 (exchange) returned no token")
         return ""
 
     # Step 3: Exchange Nebi ID token for Nebi JWT
-    return _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_url)
+    nebi_jwt = _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_url)
+    if not nebi_jwt:
+        log.error("token-exchange: aborting — step 3 (nebi session) returned no token")
+        return ""
+
+    log.info("token-exchange: all 3 steps succeeded")
+    return nebi_jwt
 
 
 # ---------------------------------------------------------------------------

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -196,6 +196,12 @@ async def _nebi_pre_spawn_hook(spawner):
     Nebi JWT, and injects it as NEBI_AUTH_TOKEN into the pod environment.
     Non-fatal: if any step fails, the pod still spawns without auto-auth.
     """
+    # Tell jhub-app-proxy to use pixi activation (instead of conda) for app pods.
+    # Set this first, before any early returns, because pixi activation is needed
+    # regardless of whether the token exchange succeeds — the nebi binary in the
+    # pod handles workspace pull and pixi env activation independently.
+    spawner.environment = {**spawner.environment, "JHUB_APP_ENV_MANAGER": "pixi"}
+
     auth_state = await spawner.user.get_auth_state()
     if not auth_state:
         log.warning("No auth_state for %s, skipping Nebi auto-auth", spawner.user.name)

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -398,6 +398,7 @@ async def _nebi_pre_spawn_hook(spawner):
             spawner.init_containers = list(spawner.init_containers) + [{
                 "name": "nebi-pull",
                 "image": spawner.image,
+                "workingDir": "/home/jovyan",
                 "command": [
                     "/bin/sh", "-c",
                     f"nebi pull {workspace_name} --force || "

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -472,7 +472,8 @@ async def _nebi_pre_spawn_hook(spawner):
                     # `pixi run` doesn't hit the ready-check timeout.
                     f"mkdir -p {ws_dir} && "
                     f"nebi pull {workspace_name} -o {ws_dir} --force && "
-                    f"pixi install --manifest-path {ws_dir}/pixi.toml || "
+                    f"pixi install --manifest-path {ws_dir}/pixi.toml && "
+                    f"chmod -R a+rw {nebi_env_dir}/nebi.db* || "
                     f"echo 'WARNING: nebi pull or pixi install failed for {workspace_name}'",
                 ],
                 "env": [

--- a/config/jupyterhub/02-jhub-apps.py
+++ b/config/jupyterhub/02-jhub-apps.py
@@ -1,6 +1,8 @@
 """jhub-apps integration configuration."""
 
 # ruff: noqa: F821 - `c` is a magic global provided by JupyterHub
+import os
+
 from kubespawner import KubeSpawner
 from jhub_apps import theme_template_paths, themes
 from jhub_apps.configuration import install_jhub_apps
@@ -36,8 +38,7 @@ c = install_jhub_apps(c, spawner_to_subclass=KubeSpawner)
 # Forward JUPYTERHUB_OIDC_CLIENT_SECRET to the jhub-apps subprocess so that
 # 03-nebi-envs.py (which is re-evaluated inside the subprocess via
 # get_jupyterhub_config()) can read it for Keycloak token exchange.
-import os as _os
-_oidc_secret = _os.environ.get("JUPYTERHUB_OIDC_CLIENT_SECRET", "")
+_oidc_secret = os.environ.get("JUPYTERHUB_OIDC_CLIENT_SECRET", "")
 if _oidc_secret:
     for svc in c.JupyterHub.services:
         if svc.get("name") == "japps":

--- a/config/jupyterhub/02-jhub-apps.py
+++ b/config/jupyterhub/02-jhub-apps.py
@@ -32,3 +32,14 @@ for key, value in japps_config.items():
 
 # Install jhub-apps (sets up service, roles, etc.)
 c = install_jhub_apps(c, spawner_to_subclass=KubeSpawner)
+
+# Forward JUPYTERHUB_OIDC_CLIENT_SECRET to the jhub-apps subprocess so that
+# 03-nebi-envs.py (which is re-evaluated inside the subprocess via
+# get_jupyterhub_config()) can read it for Keycloak token exchange.
+import os as _os
+_oidc_secret = _os.environ.get("JUPYTERHUB_OIDC_CLIENT_SECRET", "")
+if _oidc_secret:
+    for svc in c.JupyterHub.services:
+        if svc.get("name") == "japps":
+            svc.setdefault("environment", {})["JUPYTERHUB_OIDC_CLIENT_SECRET"] = _oidc_secret
+            break

--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -4,139 +4,17 @@
 import json
 import logging
 import os
-import urllib.error
-import urllib.request
-from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from z2jh import get_config
 
 log = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _extract_error_body(exc):
-    """Extract HTTP response body from an exception for diagnostic logging.
-
-    urllib.error.HTTPError exposes the body via .read(); other exceptions
-    do not.  Returns an empty string if the body cannot be read.
-    """
-    if hasattr(exc, "read"):
-        try:
-            return exc.read().decode("utf-8", errors="replace")
-        except Exception:
-            pass
-    return ""
-
-
-# ---------------------------------------------------------------------------
-# Synchronous Keycloak token exchange helpers
-# ---------------------------------------------------------------------------
-# jhub-apps calls the conda_envs callable synchronously from its FastAPI
-# service, so we MUST use urllib.request (not async Tornado).
-# The token exchange logic mirrors 01-spawner.py but is synchronous.
-
-
-def _sync_refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_client_secret):
-    """Use the refresh token to get a fresh access token from Keycloak.
-
-    Returns the new access token string, or empty string on failure.
-    """
-    body = urlencode({
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": hub_client_id,
-        "client_secret": hub_client_secret,
-    }).encode("utf-8")
-    req = Request(
-        keycloak_url,
-        data=body,
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        method="POST",
-    )
-    try:
-        with urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read())
-            return data.get("access_token", "")
-    except Exception as exc:
-        resp_body = _extract_error_body(exc)
-        log.error(
-            "nebi-envs: Keycloak token refresh failed: %s response=%s (url=%s, client_id=%s)",
-            exc, resp_body, keycloak_url, hub_client_id,
-        )
-        return ""
-
-
-def _sync_exchange_access_token_for_nebi_id_token(
-    access_token, keycloak_url, nebi_client_id, hub_client_id, hub_client_secret,
-):
-    """Exchange a JupyterHub access token for a Nebi-audience ID token via Keycloak.
-
-    Returns the Nebi ID token string, or empty string on failure.
-    """
-    body = urlencode({
-        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-        "subject_token": access_token,
-        "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
-        "audience": nebi_client_id,
-        "client_id": hub_client_id,
-        "client_secret": hub_client_secret,
-    }).encode("utf-8")
-    req = Request(
-        keycloak_url,
-        data=body,
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        method="POST",
-    )
-    try:
-        with urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read())
-            # Prefer id_token if present (has user identity claims), fall back to access_token
-            return data.get("id_token") or data.get("access_token", "")
-    except Exception as exc:
-        resp_body = _extract_error_body(exc)
-        log.error(
-            "nebi-envs: Keycloak token exchange failed: %s response=%s (url=%s, audience=%s, client_id=%s)",
-            exc, resp_body, keycloak_url, nebi_client_id, hub_client_id,
-        )
-        return ""
-
-
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Prevent urllib from following redirects (matches async follow_redirects=False)."""
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        raise urllib.error.HTTPError(newurl, code, msg, headers, fp)
-
-
-def _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
-    """Exchange a Nebi-audience ID token for a Nebi JWT via the session endpoint.
-
-    Uses a no-redirect opener to match the async version's follow_redirects=False.
-    Returns the Nebi JWT string, or empty string on failure.
-    """
-    session_url = f"{nebi_internal_url.rstrip('/')}/api/v1/auth/session"
-    req = Request(
-        session_url,
-        headers={"Cookie": f"IdToken={nebi_id_token}"},
-        method="GET",
-    )
-    opener = urllib.request.build_opener(_NoRedirectHandler)
-    try:
-        with opener.open(req, timeout=10) as resp:
-            data = json.loads(resp.read())
-            return data.get("token", "")
-    except Exception as exc:
-        resp_body = _extract_error_body(exc)
-        log.error(
-            "nebi-envs: Nebi session exchange failed: %s response=%s (url=%s)",
-            exc, resp_body, session_url,
-        )
-        return ""
+# Token exchange functions (_extract_error_body, _sync_refresh_access_token,
+# _sync_exchange_access_token_for_nebi_id_token,
+# _sync_exchange_nebi_id_token_for_jwt, get_nebi_jwt) are defined in
+# 01-spawner.py which loads first.  JupyterHub executes config files in the
+# same namespace, so they are available here as globals.
 
 
 # ---------------------------------------------------------------------------
@@ -196,36 +74,16 @@ def get_nebi_environments(user):
         return []
 
     try:
-        # Step 1: Refresh the access token (preferred) or use existing one
-        if refresh_token:
-            access_token = _sync_refresh_access_token(
-                refresh_token, keycloak_url, hub_cid, hub_secret,
-            )
-            if not access_token:
-                log.warning(
-                    "nebi-envs: token refresh returned no access token for %s", username,
-                )
-                return []
-
-        # Step 2: Exchange access token for Nebi-audience ID token
-        nebi_id_token = _sync_exchange_access_token_for_nebi_id_token(
-            access_token, keycloak_url, nebi_cid, hub_cid, hub_secret,
+        # Reuse the shared token exchange from 01-spawner.py
+        nebi_jwt = get_nebi_jwt(
+            refresh_token, access_token,
+            keycloak_url, nebi_cid, hub_cid, hub_secret, nebi_url,
         )
-        if not nebi_id_token:
-            log.warning(
-                "nebi-envs: Keycloak token exchange returned no token for %s", username,
-            )
-            return []
-
-        # Step 3: Exchange Nebi ID token for Nebi JWT
-        nebi_jwt = _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_url)
         if not nebi_jwt:
-            log.warning(
-                "nebi-envs: Nebi session returned no JWT for %s", username,
-            )
+            log.warning("nebi-envs: token exchange returned no JWT for %s", username)
             return []
 
-        # Step 4: Fetch workspaces from Nebi API
+        # Fetch workspaces from Nebi API
         workspaces_url = f"{nebi_url.rstrip('/')}/api/v1/workspaces"
         req = Request(
             workspaces_url,
@@ -242,7 +100,7 @@ def get_nebi_environments(user):
             )
             return []
 
-        # Step 5: Validate response shape and filter to ready workspaces
+        # Validate response shape and filter to ready workspaces
         if not isinstance(workspaces, list):
             log.error(
                 "nebi-envs: unexpected workspaces response type %s for %s (expected list)",

--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -4,6 +4,8 @@
 import json
 import logging
 import os
+import time
+import threading
 from urllib.request import Request, urlopen
 
 from z2jh import get_config
@@ -15,6 +17,37 @@ log = logging.getLogger(__name__)
 # _sync_exchange_nebi_id_token_for_jwt, get_nebi_jwt) are defined in
 # 01-spawner.py which loads first.  JupyterHub executes config files in the
 # same namespace, so they are available here as globals.
+
+
+# ---------------------------------------------------------------------------
+# Per-user cache for nebi JWT + workspace list
+# ---------------------------------------------------------------------------
+# The nebi JWT has a 24h lifetime.  Rather than doing the full 3-step token
+# exchange on every /conda-environments/ request (which jhub-apps fires on
+# every page load), cache the result per user.
+#
+# Cache entry: (nebi_jwt, workspace_list, expiry_timestamp)
+# TTL: 10 minutes — short enough to pick up new workspaces reasonably fast,
+#       long enough to avoid hammering Keycloak on every page load.
+
+_CACHE_TTL_SECONDS = 600  # 10 minutes
+_cache = {}  # username -> (nebi_jwt, workspace_list, expiry_timestamp)
+_cache_lock = threading.Lock()
+
+
+def _cache_get(username):
+    """Return cached (nebi_jwt, workspace_list) if still valid, else None."""
+    with _cache_lock:
+        entry = _cache.get(username)
+        if entry and entry[2] > time.time():
+            return entry[0], entry[1]
+        return None
+
+
+def _cache_set(username, nebi_jwt, workspace_list):
+    """Store (nebi_jwt, workspace_list) in cache with TTL."""
+    with _cache_lock:
+        _cache[username] = (nebi_jwt, workspace_list, time.time() + _CACHE_TTL_SECONDS)
 
 
 # ---------------------------------------------------------------------------
@@ -31,6 +64,13 @@ def get_nebi_environments(user):
     On any failure, returns an empty list (graceful degradation).
     """
     username = user.get("name", "<unknown>")
+
+    # Check cache first — avoids the 3-step token exchange on every page load
+    cached = _cache_get(username)
+    if cached is not None:
+        _, workspace_list = cached
+        log.info("nebi-envs: returning %d cached environments for %s", len(workspace_list), username)
+        return workspace_list
 
     # Read config values
     keycloak_url = get_config("custom.keycloak-token-url", "")
@@ -155,9 +195,10 @@ def get_nebi_environments(user):
             if owner_username and ws_name:
                 envs.append(f"{owner_username}/{ws_name}")
 
+        _cache_set(username, nebi_jwt, envs)
         log.info(
-            "nebi-envs: listed %d ready environments for %s (total workspaces: %d)",
-            len(envs), username, len(workspaces),
+            "nebi-envs: listed %d ready environments for %s (total workspaces: %d, cached for %ds)",
+            len(envs), username, len(workspaces), _CACHE_TTL_SECONDS,
         )
         return envs
 

--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -4,8 +4,6 @@
 import json
 import logging
 import os
-import time
-import threading
 from urllib.request import Request, urlopen
 
 from z2jh import get_config
@@ -17,37 +15,6 @@ log = logging.getLogger(__name__)
 # _sync_exchange_nebi_id_token_for_jwt, get_nebi_jwt) are defined in
 # 01-spawner.py which loads first.  JupyterHub executes config files in the
 # same namespace, so they are available here as globals.
-
-
-# ---------------------------------------------------------------------------
-# Per-user cache for nebi JWT + workspace list
-# ---------------------------------------------------------------------------
-# The nebi JWT has a 24h lifetime.  Rather than doing the full 3-step token
-# exchange on every /conda-environments/ request (which jhub-apps fires on
-# every page load), cache the result per user.
-#
-# Cache entry: (nebi_jwt, workspace_list, expiry_timestamp)
-# TTL: 10 minutes — short enough to pick up new workspaces reasonably fast,
-#       long enough to avoid hammering Keycloak on every page load.
-
-_CACHE_TTL_SECONDS = 600  # 10 minutes
-_cache = {}  # username -> (nebi_jwt, workspace_list, expiry_timestamp)
-_cache_lock = threading.Lock()
-
-
-def _cache_get(username):
-    """Return cached (nebi_jwt, workspace_list) if still valid, else None."""
-    with _cache_lock:
-        entry = _cache.get(username)
-        if entry and entry[2] > time.time():
-            return entry[0], entry[1]
-        return None
-
-
-def _cache_set(username, nebi_jwt, workspace_list):
-    """Store (nebi_jwt, workspace_list) in cache with TTL."""
-    with _cache_lock:
-        _cache[username] = (nebi_jwt, workspace_list, time.time() + _CACHE_TTL_SECONDS)
 
 
 # ---------------------------------------------------------------------------
@@ -64,13 +31,6 @@ def get_nebi_environments(user):
     On any failure, returns an empty list (graceful degradation).
     """
     username = user.get("name", "<unknown>")
-
-    # Check cache first — avoids the 3-step token exchange on every page load
-    cached = _cache_get(username)
-    if cached is not None:
-        _, workspace_list = cached
-        log.info("nebi-envs: returning %d cached environments for %s", len(workspace_list), username)
-        return workspace_list
 
     # Read config values
     keycloak_url = get_config("custom.keycloak-token-url", "")
@@ -195,10 +155,9 @@ def get_nebi_environments(user):
             if owner_username and ws_name:
                 envs.append(f"{owner_username}/{ws_name}")
 
-        _cache_set(username, nebi_jwt, envs)
         log.info(
-            "nebi-envs: listed %d ready environments for %s (total workspaces: %d, cached for %ds)",
-            len(envs), username, len(workspaces), _CACHE_TTL_SECONDS,
+            "nebi-envs: listed %d ready environments for %s (total workspaces: %d)",
+            len(envs), username, len(workspaces),
         )
         return envs
 

--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -93,6 +93,13 @@ def get_nebi_environments(user):
         log.warning("nebi-envs: no auth_state for user %s, cannot list environments", username)
         return []
 
+    log.info(
+        "nebi-envs: auth_state for %s — keys=%s, has_refresh_token=%s, has_access_token=%s, source=%s",
+        username, list(auth_state.keys()),
+        bool(auth_state.get("refresh_token")),
+        bool(auth_state.get("access_token")),
+        "user_dict" if user.get("auth_state") else "hub_api_fallback",
+    )
     refresh_token = auth_state.get("refresh_token")
     access_token = auth_state.get("access_token", "")
 

--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -1,0 +1,290 @@
+"""Nebi environment listing for jhub-apps environment selector."""
+# ruff: noqa: F821 - `c` is a magic global provided by JupyterHub
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from z2jh import get_config
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_error_body(exc):
+    """Extract HTTP response body from an exception for diagnostic logging.
+
+    urllib.error.HTTPError exposes the body via .read(); other exceptions
+    do not.  Returns an empty string if the body cannot be read.
+    """
+    if hasattr(exc, "read"):
+        try:
+            return exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            pass
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Synchronous Keycloak token exchange helpers
+# ---------------------------------------------------------------------------
+# jhub-apps calls the conda_envs callable synchronously from its FastAPI
+# service, so we MUST use urllib.request (not async Tornado).
+# The token exchange logic mirrors 01-spawner.py but is synchronous.
+
+
+def _sync_refresh_access_token(refresh_token, keycloak_url, hub_client_id, hub_client_secret):
+    """Use the refresh token to get a fresh access token from Keycloak.
+
+    Returns the new access token string, or empty string on failure.
+    """
+    body = urlencode({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": hub_client_id,
+        "client_secret": hub_client_secret,
+    }).encode("utf-8")
+    req = Request(
+        keycloak_url,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            return data.get("access_token", "")
+    except Exception as exc:
+        resp_body = _extract_error_body(exc)
+        log.error(
+            "nebi-envs: Keycloak token refresh failed: %s response=%s (url=%s, client_id=%s)",
+            exc, resp_body, keycloak_url, hub_client_id,
+        )
+        return ""
+
+
+def _sync_exchange_access_token_for_nebi_id_token(
+    access_token, keycloak_url, nebi_client_id, hub_client_id, hub_client_secret,
+):
+    """Exchange a JupyterHub access token for a Nebi-audience ID token via Keycloak.
+
+    Returns the Nebi ID token string, or empty string on failure.
+    """
+    body = urlencode({
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": access_token,
+        "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        "audience": nebi_client_id,
+        "client_id": hub_client_id,
+        "client_secret": hub_client_secret,
+    }).encode("utf-8")
+    req = Request(
+        keycloak_url,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            # Prefer id_token if present (has user identity claims), fall back to access_token
+            return data.get("id_token") or data.get("access_token", "")
+    except Exception as exc:
+        resp_body = _extract_error_body(exc)
+        log.error(
+            "nebi-envs: Keycloak token exchange failed: %s response=%s (url=%s, audience=%s, client_id=%s)",
+            exc, resp_body, keycloak_url, nebi_client_id, hub_client_id,
+        )
+        return ""
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Prevent urllib from following redirects (matches async follow_redirects=False)."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(newurl, code, msg, headers, fp)
+
+
+def _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_internal_url):
+    """Exchange a Nebi-audience ID token for a Nebi JWT via the session endpoint.
+
+    Uses a no-redirect opener to match the async version's follow_redirects=False.
+    Returns the Nebi JWT string, or empty string on failure.
+    """
+    session_url = f"{nebi_internal_url.rstrip('/')}/api/v1/auth/session"
+    req = Request(
+        session_url,
+        headers={"Cookie": f"IdToken={nebi_id_token}"},
+        method="GET",
+    )
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    try:
+        with opener.open(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            return data.get("token", "")
+    except Exception as exc:
+        resp_body = _extract_error_body(exc)
+        log.error(
+            "nebi-envs: Nebi session exchange failed: %s response=%s (url=%s)",
+            exc, resp_body, session_url,
+        )
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Nebi environment listing callable
+# ---------------------------------------------------------------------------
+
+def get_nebi_environments(user):
+    """Return list of ready nebi workspaces as '{owner_username}/{workspace_name}' strings.
+
+    Called synchronously by jhub-apps to populate the environment selector dropdown.
+    The `user` parameter is a dict from the JupyterHub API, containing:
+      {"name": "alice", "auth_state": {"access_token": "...", "refresh_token": "..."}, ...}
+
+    On any failure, returns an empty list (graceful degradation).
+    """
+    username = user.get("name", "<unknown>")
+
+    # Read config values
+    keycloak_url = get_config("custom.keycloak-token-url", "")
+    nebi_cid = get_config("custom.nebi-client-id", "")
+    hub_cid = get_config("custom.jupyterhub-client-id", "")
+    hub_secret = os.environ.get("JUPYTERHUB_OIDC_CLIENT_SECRET", "")
+    nebi_url = get_config("custom.nebi-internal-url", "")
+
+    if not all([keycloak_url, nebi_cid, hub_cid, hub_secret, nebi_url]):
+        missing = []
+        if not keycloak_url:
+            missing.append("keycloak-token-url")
+        if not nebi_cid:
+            missing.append("nebi-client-id")
+        if not hub_cid:
+            missing.append("jupyterhub-client-id")
+        if not hub_secret:
+            missing.append("JUPYTERHUB_OIDC_CLIENT_SECRET")
+        if not nebi_url:
+            missing.append("nebi-internal-url")
+        log.error(
+            "nebi-envs: cannot list environments for %s, missing config: %s",
+            username, ", ".join(missing),
+        )
+        return []
+
+    # Extract auth_state from user dict
+    auth_state = user.get("auth_state")
+    if not auth_state:
+        log.warning("nebi-envs: no auth_state for user %s, cannot list environments", username)
+        return []
+
+    refresh_token = auth_state.get("refresh_token")
+    access_token = auth_state.get("access_token", "")
+
+    if not refresh_token and not access_token:
+        log.warning(
+            "nebi-envs: no access_token or refresh_token for user %s, cannot list environments",
+            username,
+        )
+        return []
+
+    try:
+        # Step 1: Refresh the access token (preferred) or use existing one
+        if refresh_token:
+            access_token = _sync_refresh_access_token(
+                refresh_token, keycloak_url, hub_cid, hub_secret,
+            )
+            if not access_token:
+                log.warning(
+                    "nebi-envs: token refresh returned no access token for %s", username,
+                )
+                return []
+
+        # Step 2: Exchange access token for Nebi-audience ID token
+        nebi_id_token = _sync_exchange_access_token_for_nebi_id_token(
+            access_token, keycloak_url, nebi_cid, hub_cid, hub_secret,
+        )
+        if not nebi_id_token:
+            log.warning(
+                "nebi-envs: Keycloak token exchange returned no token for %s", username,
+            )
+            return []
+
+        # Step 3: Exchange Nebi ID token for Nebi JWT
+        nebi_jwt = _sync_exchange_nebi_id_token_for_jwt(nebi_id_token, nebi_url)
+        if not nebi_jwt:
+            log.warning(
+                "nebi-envs: Nebi session returned no JWT for %s", username,
+            )
+            return []
+
+        # Step 4: Fetch workspaces from Nebi API
+        workspaces_url = f"{nebi_url.rstrip('/')}/api/v1/workspaces"
+        req = Request(
+            workspaces_url,
+            headers={"Authorization": f"Bearer {nebi_jwt}"},
+            method="GET",
+        )
+        try:
+            with urlopen(req, timeout=10) as resp:
+                workspaces = json.loads(resp.read())
+        except Exception as exc:
+            log.error(
+                "nebi-envs: failed to fetch workspaces for %s: %s (url=%s)",
+                username, exc, workspaces_url,
+            )
+            return []
+
+        # Step 5: Validate response shape and filter to ready workspaces
+        if not isinstance(workspaces, list):
+            log.error(
+                "nebi-envs: unexpected workspaces response type %s for %s (expected list)",
+                type(workspaces).__name__, username,
+            )
+            return []
+
+        envs = []
+        for ws in workspaces:
+            if ws.get("status") != "ready":
+                continue
+            owner = ws.get("owner", {})
+            owner_username = owner.get("username", "")
+            ws_name = ws.get("name", "")
+            if owner_username and ws_name:
+                envs.append(f"{owner_username}/{ws_name}")
+
+        log.info(
+            "nebi-envs: listed %d ready environments for %s (total workspaces: %d)",
+            len(envs), username, len(workspaces),
+        )
+        return envs
+
+    except Exception:
+        log.exception(
+            "nebi-envs: unexpected error listing environments for %s", username,
+        )
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Register the callable with jhub-apps (only when enabled)
+# ---------------------------------------------------------------------------
+_nebi_env_selector = get_config("custom.nebi-environment-selector", False)
+_nebi_internal_url = get_config("custom.nebi-internal-url", "")
+
+if _nebi_env_selector and _nebi_internal_url:
+    c.JAppsConfig.conda_envs = get_nebi_environments
+    log.info("nebi-envs: environment selector enabled (nebi_url=%s)", _nebi_internal_url)
+else:
+    if _nebi_env_selector and not _nebi_internal_url:
+        log.warning(
+            "nebi-envs: nebi-environment-selector is true but nebi-internal-url is not set, "
+            "environment selector will not be enabled"
+        )

--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -75,6 +75,16 @@ def get_nebi_environments(user):
                 )
                 with urlopen(req, timeout=10) as resp:
                     auth_state = json.loads(resp.read()).get("auth_state")
+                if auth_state:
+                    log.info(
+                        "nebi-envs: fetched auth_state for %s via hub API — keys=%s, "
+                        "has_refresh_token=%s, has_access_token=%s",
+                        username, list(auth_state.keys()),
+                        bool(auth_state.get("refresh_token")),
+                        bool(auth_state.get("access_token")),
+                    )
+                else:
+                    log.warning("nebi-envs: hub API returned auth_state=None for %s", username)
             except Exception as exc:
                 log.error("nebi-envs: failed to fetch auth_state for %s: %s", username, exc)
         else:

--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -57,8 +57,28 @@ def get_nebi_environments(user):
         )
         return []
 
-    # Extract auth_state from user dict
+    # Extract auth_state from user dict.  jhub-apps fetches the user with a
+    # per-user token that lacks admin:auth_state scope, so auth_state is
+    # usually None.  Fall back to fetching it directly using the jhub-apps
+    # service API token (JUPYTERHUB_API_TOKEN) which has admin:auth_state.
+    # This is still per-user: we read THIS user's Keycloak tokens, then
+    # exchange them for a nebi JWT scoped to this user.
     auth_state = user.get("auth_state")
+    if not auth_state:
+        api_url = os.environ.get("JUPYTERHUB_API_URL", "")
+        api_token = os.environ.get("JUPYTERHUB_API_TOKEN", "")
+        if api_url and api_token:
+            try:
+                req = Request(
+                    f"{api_url}/users/{username}",
+                    headers={"Authorization": f"token {api_token}"},
+                )
+                with urlopen(req, timeout=10) as resp:
+                    auth_state = json.loads(resp.read()).get("auth_state")
+            except Exception as exc:
+                log.error("nebi-envs: failed to fetch auth_state for %s: %s", username, exc)
+        else:
+            log.warning("nebi-envs: JUPYTERHUB_API_URL/TOKEN not set, cannot fetch auth_state")
     if not auth_state:
         log.warning("nebi-envs: no auth_state for user %s, cannot list environments", username)
         return []

--- a/templates/hub-config.yaml
+++ b/templates/hub-config.yaml
@@ -11,3 +11,5 @@ data:
 {{ .Files.Get "config/jupyterhub/01-spawner.py" | indent 4 }}
   02-jhub-apps.py: |
 {{ .Files.Get "config/jupyterhub/02-jhub-apps.py" | indent 4 }}
+  03-nebi-envs.py: |
+{{ .Files.Get "config/jupyterhub/03-nebi-envs.py" | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -103,6 +103,7 @@ jupyterhub:
     keycloak-token-url: ""   # e.g., http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token
     nebi-client-id: ""       # Nebi's Keycloak OIDC client ID
     jupyterhub-client-id: "" # JupyterHub's Keycloak OIDC client ID
+    nebi-environment-selector: false  # Set true to show nebi workspaces in jhub-apps env dropdown
     # jhub-apps (JAppsConfig) overrides.
     # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
     # See https://jhub-apps.nebari.dev/docs/configuration for available options.


### PR DESCRIPTION
## Summary

- Add `config/jupyterhub/03-nebi-envs.py` — synchronous callable that queries the nebi API to list workspaces for the jhub-apps environment selector dropdown
- Extend `_nebi_pre_spawn_hook` in `01-spawner.py` to set `JHUB_APP_ENV_MANAGER=pixi` so jhub-app-proxy uses pixi activation
- Add `nebi-environment-selector` toggle in `values.yaml` (defaults to `false`)

## How it works

When `nebi-environment-selector: true`, the hub loads `03-nebi-envs.py` which sets `c.JAppsConfig.conda_envs` to a callable. When a user opens the jhub-apps app creation form, this callable:

1. Extracts the user's Keycloak refresh token from `auth_state`
2. Performs a 3-step synchronous token exchange (refresh → RFC 8693 exchange → nebi JWT)
3. Calls `GET /api/v1/workspaces` with the JWT
4. Returns `["owner/workspace-name", ...]` for ready workspaces

The spawner hook sets `JHUB_APP_ENV_MANAGER=pixi` in all nebi-configured pods (before any early returns), telling jhub-app-proxy to use pixi activation instead of conda.

Depends on nebari-dev/jhub-app-proxy#15 for the pixi activation support in jhub-app-proxy.

Closes #26

## Test plan

- [x] Python syntax validation passes for both modified files
- [x] All error paths return empty list (graceful degradation)
- [x] Error body extraction from HTTP errors for diagnostic logging
- [x] No-redirect handler on session endpoint (matches async `follow_redirects=False`)
- [x] Response type validation for workspaces API
- [ ] End-to-end: deploy to hetzner-nebari with `nebi-environment-selector: true`, create workspace in nebi, verify dropdown shows `owner/workspace-name`