### PR TITLE
fix: add descriptive names to default server profiles

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -143,16 +143,16 @@ jupyterhub:
     # mem_limit, node_selector, image, extra_resource_limits, etc.).
     # Set to [] to disable the profile selector (single-instance mode).
     profiles:
-      - display_name: "Small"
-        description: "1 CPU / 2 GB RAM"
+      - display_name: "Small Instance"
+        description: "Stable environment with 1 CPU / 2 GB RAM"
         default: true
         kubespawner_override:
           cpu_limit: 1
           cpu_guarantee: 0.5
           mem_limit: "2G"
           mem_guarantee: "1G"
-      - display_name: "Medium"
-        description: "4 CPU / 8 GB RAM"
+      - display_name: "Medium Instance"
+        description: "Stable environment with 4 CPU / 8 GB RAM"
         kubespawner_override:
           cpu_limit: 4
           cpu_guarantee: 2


### PR DESCRIPTION
## Summary
- Update default profile `display_name` from "Small"/"Medium" to "Small Instance"/"Medium Instance"
- Update default profile `description` to include "Stable environment with..." prefix for better UX

## Test plan
- [ ] Deploy chart and verify spawn page shows updated profile names and descriptions