### PR TITLE
fix: don't invalidate session when IdToken cookie is missing

### DIFF
--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -135,9 +135,15 @@ class EnvoyOIDCAuthenticator(Authenticator):
         id_token, access_token, refresh_token = self._extract_envoy_cookies(handler)
 
         if not id_token:
-            # Cookies missing — session may have expired, force re-login
-            self.log.warning("refresh_user: no IdToken cookie for %s, invalidating session", user.name)
-            return False
+            # No IdToken cookie — this happens on internal API calls from
+            # singleuser pods (e.g. activity pings) where no browser cookies
+            # are present.  Return True to keep the session alive; only
+            # browser requests carry the Envoy OIDC cookies.
+            self.log.debug(
+                "refresh_user: no IdToken cookie for %s (likely internal API call), keeping session",
+                user.name,
+            )
+            return True
 
         auth_state = {
             k: v for k, v in {

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -135,12 +135,24 @@ class EnvoyOIDCAuthenticator(Authenticator):
         id_token, access_token, refresh_token = self._extract_envoy_cookies(handler)
 
         if not id_token:
-            # No IdToken cookie — this happens on internal API calls from
-            # singleuser pods (e.g. activity pings) where no browser cookies
-            # are present.  Return True to keep the session alive; only
-            # browser requests carry the Envoy OIDC cookies.
+            # This method is called on an already-authenticated user —
+            # JupyterHub has already validated the request (via OAuth token
+            # or API token) before calling refresh_user.  We are NOT doing
+            # authentication here; we're just deciding whether to update
+            # auth_state with fresh Envoy cookies or keep the existing session.
+            #
+            # Envoy OIDC cookies (IdToken, AccessToken) are only present on
+            # browser requests.  Requests from singleuser pods (e.g. activity
+            # pings via JUPYTERHUB_API_TOKEN) have a handler but no cookies.
+            # Returning False here would invalidate the entire session,
+            # causing 403s on all subsequent requests including the browser.
+            #
+            # Instead, skip the auth_state refresh and keep the session alive.
+            # Envoy Gateway handles token refresh independently at the gateway
+            # layer — the next browser request will carry fresh cookies and
+            # update auth_state then.
             self.log.debug(
-                "refresh_user: no IdToken cookie for %s (likely internal API call), keeping session",
+                "refresh_user: no IdToken cookie for %s, skipping auth_state refresh",
                 user.name,
             )
             return True


### PR DESCRIPTION
## Problem

JupyterLab sessions break with 403 Forbidden errors exactly 5 minutes after login. Users see WebSocket disconnects, file save errors, and XSRF cookie mismatches — all requiring a page refresh to temporarily fix.

## Root Cause

The `EnvoyOIDCAuthenticator.refresh_user()` method is called by JupyterHub every 60 seconds (`auth_refresh_age = 60`) to re-validate the user's session. It reads the Envoy OIDC `IdToken` cookie from the request to keep `auth_state` fresh.

The problem: **not all requests carry browser cookies**. The singleuser server makes internal API calls to the hub (e.g. `POST /hub/api/users/{user}/activity` for activity pings) that go through JupyterHub's internal proxy. These requests have a `handler` object but **no browser cookies** — because they originate from the pod, not the browser.

When `refresh_user` runs on one of these internal requests:
1. `handler` is not `None` (so the early return doesn't fire)
2. `_extract_envoy_cookies(handler)` finds no `IdToken` cookie
3. The code returns `False` → JupyterHub **invalidates the entire session**
4. All subsequent requests (browser and internal) get 403 Forbidden

The 5-minute timing matches Keycloak's `accessTokenLifespan: 300` (5 minutes). After 5 minutes, the access token expires and the next activity ping from the singleuser pod triggers `refresh_user` — which kills the session.

## Fix

When no `IdToken` cookie is found, return `True` (keep session alive) instead of `False` (invalidate). The absence of cookies means this is an internal API call without browser context — not an expired session.

```python
# Before (broken)
if not id_token:
    self.log.warning("refresh_user: no IdToken cookie for %s, invalidating session", user.name)
    return False

# After (fixed)
if not id_token:
    self.log.debug(
        "refresh_user: no IdToken cookie for %s (likely internal API call), keeping session",
        user.name,
    )
    return True
```

Browser requests with genuinely expired cookies will still trigger re-authentication via Envoy Gateway's OIDC filter (which handles token refresh independently using its own refresh token).