### PR TITLE
chore: bump default image tags to sha-8f2e545 (launchpad fix)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -194,7 +194,7 @@ jupyterhub:
     # Custom Nebari hub image with jhub-apps pre-installed
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterhub
-      tag: "sha-443d1fe"
+      tag: "sha-8f2e545"
 
     config:
       JupyterHub:
@@ -252,7 +252,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterlab
-      tag: "sha-443d1fe"
+      tag: "sha-8f2e545"
     defaultUrl: "/lab"
     extraEnv:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"


### PR DESCRIPTION
## Summary

Bumps the default `hub` and `singleuser` image tags in `values.yaml` from `sha-443d1fe` to `sha-8f2e545` so that new deployments pick up `jupyterlab-launchpad 1.0.5`, which fixes the activity-tracking bug discovered in https://github.com/nebari-dev/nebari-data-science-pack/pull/45.

## Why

Even though https://github.com/nebari-dev/nebari-data-science-pack/pull/45 added the singleuser-level idle culler config and bumped `jupyterlab-launchpad` to `1.0.5` in `images/jupyterlab/pixi.toml`, the chart's default image tag in `values.yaml` was never updated. As a result, deployments using the default tag still ship the old image (`sha-443d1fe`) which contains:

- `jupyterlab-launchpad 1.0.4` — `DatabaseHandler._track_activity = True`, so its 10-second polling resets `api_last_activity` and prevents `shutdown_no_activity_timeout` from ever firing.

This was confirmed in production today — a user's server had been running for 5h47m without being culled despite the 15-minute timeout because the deployed image had launchpad 1.0.4.

The image `sha-8f2e545` was built from the merge commit of https://github.com/nebari-dev/nebari-data-science-pack/pull/45 and contains `jupyterlab-launchpad 1.0.5` (with `_track_activity = False`), so the culler will now work as configured.

## Test plan

- [ ] Sync ArgoCD apps using the chart default and verify new singleuser pods use `sha-8f2e545`
- [ ] Confirm `jupyterlab_launchpad.handlers.DatabaseHandler._track_activity` is `False` in the new image
- [ ] Leave a server idle for >15 minutes (with a tab open in the background) and verify it self-terminates