### PR TITLE
test: pin nb_nebi_kernels at PR #5 for integration testing

### DIFF
--- a/images/jupyterlab/pixi.lock
+++ b/images/jupyterlab/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -460,7 +458,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
+      - pypi: git+https://github.com/MUFFANUJ/nb-nebi-kernels.git?branch=surfaceRemoteEvns#4aaeb7c5a95d4d2611846f86d306aeeb040093ea
       - pypi: https://files.pythonhosted.org/packages/b2/be/ce3368145f22d64095e03591deeb26986b749b0b1c8373d426f8312c3a96/panel-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/1c/1b83ffb56adb76abe46df91439e9a613bba45e4612a4e6a7bbebca0b35bb/plotlydash_tornado_cmd-0.0.6-py3-none-any.whl
@@ -486,7 +484,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/da/e5/148ab5edb339f5833d04f0bcb8380a53e8b19bd5f091ae67222ed188b393/uv-0.9.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl
-      - pypi: git+https://github.com/betatim/vscode-binder.git#25d70ec4ca208d01a6bcbfd616de1b2b2c7d431c
+      - pypi: git+https://github.com/betatim/vscode-binder.git#e931187cf1e5b18f93dcf133301019d93680df05
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-47.0-unix_0.conda
@@ -938,7 +936,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
+      - pypi: git+https://github.com/MUFFANUJ/nb-nebi-kernels.git?branch=surfaceRemoteEvns#4aaeb7c5a95d4d2611846f86d306aeeb040093ea
       - pypi: https://files.pythonhosted.org/packages/b2/be/ce3368145f22d64095e03591deeb26986b749b0b1c8373d426f8312c3a96/panel-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/1c/1b83ffb56adb76abe46df91439e9a613bba45e4612a4e6a7bbebca0b35bb/plotlydash_tornado_cmd-0.0.6-py3-none-any.whl
@@ -964,7 +962,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/eb/d8/a77587e4608af6efc5a72d3a937573eb5d08052550a3f248821b50898626/uv-0.9.13-py3-none-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl
-      - pypi: git+https://github.com/betatim/vscode-binder.git#25d70ec4ca208d01a6bcbfd616de1b2b2c7d431c
+      - pypi: git+https://github.com/betatim/vscode-binder.git#e931187cf1e5b18f93dcf133301019d93680df05
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -3998,9 +3996,9 @@ packages:
   - pkg:pypi/jupyter-server-proxy?source=hash-mapping
   size: 37140
   timestamp: 1734379307021
-- pypi: git+https://github.com/betatim/vscode-binder.git#25d70ec4ca208d01a6bcbfd616de1b2b2c7d431c
+- pypi: git+https://github.com/betatim/vscode-binder.git#e931187cf1e5b18f93dcf133301019d93680df05
   name: jupyter-vscode-proxy
-  version: '0.7'
+  version: 0.7.post2+ge931187cf
   requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
   sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
@@ -6432,10 +6430,9 @@ packages:
   - pkg:pypi/narwhals?source=hash-mapping
   size: 180520
   timestamp: 1741613573009
-- pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
+- pypi: git+https://github.com/MUFFANUJ/nb-nebi-kernels.git?branch=surfaceRemoteEvns#4aaeb7c5a95d4d2611846f86d306aeeb040093ea
   name: nb-nebi-kernels
-  version: '0.1'
-  sha256: cf6494d685112e43c38f04cb706320db96c526448411ca1c31f358caa50a54d4
+  version: 0.1.dev23+g4aaeb7c5a
   requires_dist:
   - jupyter-client>=8.0.0
   - jupyter-core>=5.0.0

--- a/images/jupyterlab/pixi.toml
+++ b/images/jupyterlab/pixi.toml
@@ -75,7 +75,7 @@ pyjwt = "<2.10.0"
 
 [pypi-dependencies]
 jupyter-vscode-proxy = { git = "https://github.com/betatim/vscode-binder.git" }
-nb_nebi_kernels = "==0.1"
+nb_nebi_kernels = { git = "https://github.com/MUFFANUJ/nb-nebi-kernels.git", branch = "surfaceRemoteEvns" }
 jupyterlab_nvdashboard = "==0.12.0"
 argo-jupyter-scheduler = "==2024.6.1"
 jhub-apps = "==2025.11.1"


### PR DESCRIPTION
## Summary

Pins `images/jupyterlab/pixi.toml`'s `nb_nebi_kernels` dep at MUFFANUJ's `surfaceRemoteEvns` branch (nebari-dev/nb-nebi-kernels#5) so the singleuser image build picks up the remote-kernel-surfacing changes for end-to-end validation against a Nebi server.

**DO NOT MERGE.** Integration-test scaffolding only. Once nb-nebi-kernels#5 lands and a release is cut, the production pin should bump to the tagged version (e.g. `==0.2`).

## What's in the diff

- `images/jupyterlab/pixi.toml` — `nb_nebi_kernels = "==0.1"` → `{ git = "https://github.com/MUFFANUJ/nb-nebi-kernels.git", branch = "surfaceRemoteEvns" }` (pinned in the lock to commit `4aaeb7c5a95d4d2611846f86d306aeeb040093ea`).
- `images/jupyterlab/pixi.lock` — regenerated so `pixi install --locked` (used in `images/Dockerfile`) succeeds. Note: the regeneration incidentally advanced `jupyter-vscode-proxy` from `25d70ec4` to `e931187cf` (the existing `git = ...` dep had no rev pin and tracks HEAD).

## Test plan

- [ ] `Build Docker Images` workflow produces `quay.io/nebari/nebari-data-science-pack-jupyterlab:pr-<n>` for amd64 and arm64.
- [ ] `Test Deployment` workflow (k3d) passes — confirms the new wheel installs without breaking the singleuser env.
- [ ] Manual smoke against a Nebi deployment (TBD, Hetzner): with `NEBI_REMOTE_URL` + `NEBI_AUTH_TOKEN` injected into the pod, JupyterLab surfaces remote-only workspaces as `remote-not-pulled` kernels.
- [ ] Confirm local kernel state classification (`ready`, `local-not-installed`, `local-missing-deps`) renders correctly in the launcher.

## References

- Upstream PR: nebari-dev/nb-nebi-kernels#5 (surface remote Nebi kernels)
- Tracking issue: nebari-dev/nb-nebi-kernels#2 (state, version drift, missing-dep detection)
- Pre-review local validation: 32 tests pass, ruff clean, wheel builds (`0.2.dev4+g4aaeb7c5a`).