### PR TITLE
feat: role-gated shared-mount RBAC

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,30 @@ on:
     branches: [main]
 
 jobs:
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Set up isolated Python env
+        run: |
+          uv venv .venv-unit --python 3.10
+          # Pinned versions the hub image runs against — tests exercise
+          # the real oauthenticator + jupyterhub contracts, not a stub.
+          uv pip install --python .venv-unit/bin/python \
+            jupyterhub==5.1.0 \
+            oauthenticator==16.3.0 \
+            pytest
+
+      - name: pytest tests/unit
+        run: .venv-unit/bin/python -m pytest tests/unit -v --color=yes
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ venv/
 # Pixi
 .pixi/
 .venv-unit/
+tools/

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -461,15 +461,14 @@ else:
     if os.environ.get("OAUTH_CALLBACK_URL"):
         _secret_dir = Path(os.environ.get("OAUTH_SECRET_DIR", "/etc/oauth"))
         # RBAC for role-gated /shared/<group> mounts (issue #2304).
-        # Empty realm_api_url disables RBAC; the spawner falls back to
-        # the broader auth_state.groups list. Read via z2jh.get_config
-        # (the chart's convention for `custom.*` values) rather than
-        # env vars so the values flow through ``jupyterhub.custom`` in
-        # values.yaml exactly like every other deploy-time setting.
-        try:
-            from z2jh import get_config as _z2jh_get_config
-        except ImportError:
-            _z2jh_get_config = lambda k, default=None: default  # noqa: E731
+        # Read from env vars on the hub Deployment rather than via
+        # z2jh.get_config (which sources from the hub Secret's
+        # embedded values.yaml). The Secret is hold-stable by
+        # ArgoCD-side ignoreDifferences on rotating fields, and
+        # mutating non-rotating fields inside it via Helm-template
+        # +ArgoCD-SSA doesn't reliably propagate. Env-var-on-Deployment
+        # flows through standard SSA + checksum-driven hub rollout, so
+        # it actually reaches every cluster on chart upgrade.
         configure(
             c,  # noqa: F821
             issuer=_read_secret_file(_secret_dir, "issuer-url"),
@@ -477,9 +476,9 @@ else:
             client_secret=_read_secret_file(_secret_dir, "client-secret"),
             callback_url=os.environ["OAUTH_CALLBACK_URL"],
             external_url=os.environ["OAUTH_EXTERNAL_URL"],
-            realm_api_url=_z2jh_get_config("custom.rbac-realm-api-url", ""),
-            shared_mount_role_name=_z2jh_get_config(
-                "custom.rbac-shared-mount-role-name",
+            realm_api_url=os.environ.get("KC_REALM_API_URL", ""),
+            shared_mount_role_name=os.environ.get(
+                "KC_SHARED_MOUNT_ROLE",
                 "allow-group-directory-creation-role",
             ),
         )

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -227,8 +227,9 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
     # Name of the KC client role that grants /shared/<group> mount
     # permission. The role must carry attributes
     # component=["shared-directory"] and scopes=["write:shared-mount"].
-    # Default matches classic nebari's role name so realm-setup tooling
-    # (deployment tests, kcadm scripts) stays compatible.
+    # Default name kept stable so existing realm-setup tooling
+    # (kcadm scripts, deployment tests) does not need to be edited
+    # to recognise the role.
     shared_mount_role_name = Unicode(
         "allow-group-directory-creation-role", config=True,
     )

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -391,7 +391,7 @@ def configure(
 ):
     """Wire KeyCloakOAuthenticator onto JupyterHub's `c` config object.
 
-    ``realm_api_url`` enables role-gated shared-mount RBAC (issue #2304).
+    ``realm_api_url`` enables role-gated shared-mount RBAC.
     Pass the KC Admin API root for the realm
     (e.g. ``https://kc.example/admin/realms/nebari``); leave empty to
     disable. ``shared_mount_role_name`` is the KC client role whose
@@ -461,7 +461,7 @@ except NameError:
 else:
     if os.environ.get("OAUTH_CALLBACK_URL"):
         _secret_dir = Path(os.environ.get("OAUTH_SECRET_DIR", "/etc/oauth"))
-        # RBAC for role-gated /shared/<group> mounts (issue #2304).
+        # RBAC for role-gated /shared/<group> mounts.
         # Read from env vars on the hub Deployment rather than via
         # z2jh.get_config (which sources from the hub Secret's
         # embedded values.yaml). The Secret is hold-stable by

--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -25,6 +25,98 @@ from urllib.parse import urlencode
 from oauthenticator.generic import GenericOAuthenticator
 from oauthenticator.oauth2 import OAuthLogoutHandler
 from tornado.httpclient import HTTPClientError
+from traitlets import Unicode
+
+
+class KCRealmAdmin:
+    """Keycloak Admin API client, narrowed to the one question this chart
+    needs to answer: *of the KC groups this user belongs to, which ones
+    hold the shared-directory mount role?*
+
+    Deep module: one public method (:meth:`filter_user_groups_by_role`)
+    hides four HTTP round-trips, two JSON parsings, the
+    ``client_credentials`` grant against the realm token endpoint, the
+    role-attribute validation, and the set intersection. Callers don't
+    need to know the realm API URL exists.
+
+    The class takes ``http_fetch`` as a dependency rather than building
+    its own client so tests can mock at the HTTP boundary without
+    touching authenticator internals. In production it's bound to the
+    parent ``OAuthenticator.httpfetch``.
+
+    Construction is pure; only the public method does I/O.
+    """
+
+    REQUIRED_ATTRS = {
+        "component": "shared-directory",
+        "scopes": "write:shared-mount",
+    }
+
+    def __init__(self, http_fetch, *, token_url, client_id, client_secret, realm_api_url):
+        self._http_fetch = http_fetch
+        self._token_url = token_url
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._realm_api_url = realm_api_url
+
+    async def filter_user_groups_by_role(self, user_groups, role_name):
+        """Return the subset of ``user_groups`` (KC group paths) whose
+        members hold ``role_name`` on the configured OAuth client.
+
+        Returns ``[]`` if the role exists but lacks the required
+        ``component=shared-directory`` + ``scopes=write:shared-mount``
+        attributes — safer to grant no mounts than to grant all groups.
+
+        Raises whatever the underlying HTTP fetcher raises on transport
+        failure; callers handle.
+        """
+        token = await self._client_credentials_token()
+        client_uuid = await self._lookup_client_uuid(token, self._client_id)
+        role = await self._admin_get(token, f"/clients/{client_uuid}/roles/{role_name}")
+        if not self._role_has_required_attributes(role):
+            return []
+        role_groups = await self._admin_get(
+            token, f"/clients/{client_uuid}/roles/{role_name}/groups",
+        )
+        role_paths = {g.get("path") for g in role_groups if g.get("path")}
+        return [g for g in user_groups if g in role_paths]
+
+    # --- internals (each step is one HTTP round-trip) -------------------
+
+    async def _client_credentials_token(self):
+        body = urlencode({
+            "grant_type": "client_credentials",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+        })
+        token_info = await self._http_fetch(
+            self._token_url,
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=body,
+        )
+        return token_info["access_token"]
+
+    async def _lookup_client_uuid(self, token, client_id):
+        clients = await self._admin_get(token, f"/clients?clientId={client_id}")
+        if not clients:
+            raise RuntimeError(f"KC client {client_id!r} not found in realm")
+        return clients[0]["id"]
+
+    async def _admin_get(self, token, path):
+        return await self._http_fetch(
+            f"{self._realm_api_url}{path}",
+            method="GET",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    @classmethod
+    def _role_has_required_attributes(cls, role):
+        attrs = role.get("attributes", {}) or {}
+        for key, expected in cls.REQUIRED_ATTRS.items():
+            if expected not in (attrs.get(key) or []):
+                return False
+        return True
 
 
 @dataclass(frozen=True)
@@ -125,6 +217,22 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
     # via `c.<Class>.<attr>` assignment.
     kc_config: "KeyCloakConfig | None" = None
 
+    # KC Admin API URL for the realm (e.g.
+    # https://keycloak.example/admin/realms/nebari). Used by
+    # update_auth_model to resolve which of a user's groups hold the
+    # shared-directory mount role. Empty disables RBAC entirely —
+    # auth_state["groups_with_permission_to_mount"] is not set, and the
+    # spawner falls back to its existing behaviour.
+    realm_api_url = Unicode("", config=True)
+    # Name of the KC client role that grants /shared/<group> mount
+    # permission. The role must carry attributes
+    # component=["shared-directory"] and scopes=["write:shared-mount"].
+    # Default matches classic nebari's role name so realm-setup tooling
+    # (deployment tests, kcadm scripts) stays compatible.
+    shared_mount_role_name = Unicode(
+        "allow-group-directory-creation-role", config=True,
+    )
+
     async def refresh_user(self, user, handler=None):
         """Run KC's refresh_token grant and persist rotated tokens to auth_state.
 
@@ -194,7 +302,78 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
         if token_info.get("id_token"):
             new_state["id_token"] = token_info["id_token"]
         new_state["token_response"] = token_info
+        if self.realm_api_url:
+            # Re-evaluate the role-gated mount filter against current KC
+            # state. KC role/group changes mid-session take effect on
+            # this user's next spawn — no force-relogin needed.
+            user_groups = new_state.get("oauth_user", {}).get("groups", [])
+            try:
+                new_state["groups_with_permission_to_mount"] = (
+                    await self._realm_admin().filter_user_groups_by_role(
+                        user_groups, self.shared_mount_role_name,
+                    )
+                )
+            except Exception:
+                self.log.warning(
+                    "rbac: failed to refresh groups_with_permission_to_mount "
+                    "for %s — keeping last known set",
+                    user.name, exc_info=True,
+                )
+                # Preserve whatever was already there if the prior auth had it.
+                old_filter = auth_state.get("groups_with_permission_to_mount")
+                if old_filter is not None:
+                    new_state["groups_with_permission_to_mount"] = old_filter
         return {"auth_state": new_state}
+
+    async def update_auth_model(self, auth_model):
+        """Stamp auth_state with the subset of KC groups that hold the
+        shared-mount role.
+
+        JupyterHub calls this on every login (and on every refresh once
+        the parent class is configured to do so). The spawner reads
+        ``auth_state["groups_with_permission_to_mount"]`` at spawn time
+        to decide which ``/shared/<group>`` dirs to mount — being in a
+        KC group is necessary but not sufficient; the group also has to
+        hold the shared-directory role.
+
+        Disabled cleanly when ``realm_api_url`` is empty. KC Admin API
+        failures (no SA on the OAuth client, network blip, 5xx) are
+        logged and degraded to an empty set — login itself MUST succeed
+        regardless of realm-admin reachability.
+        """
+        auth_model = await super().update_auth_model(auth_model)
+        if not self.realm_api_url:
+            return auth_model
+        user_groups = (
+            auth_model.get("auth_state", {})
+            .get("oauth_user", {})
+            .get("groups", [])
+        )
+        try:
+            filtered = await self._realm_admin().filter_user_groups_by_role(
+                user_groups, self.shared_mount_role_name,
+            )
+        except Exception:
+            self.log.warning(
+                "rbac: failed to compute groups_with_permission_to_mount "
+                "for %s — granting no shared mounts this session",
+                auth_model.get("name"), exc_info=True,
+            )
+            filtered = []
+        auth_model["auth_state"]["groups_with_permission_to_mount"] = filtered
+        return auth_model
+
+    def _realm_admin(self):
+        """Build a :class:`KCRealmAdmin` from the authenticator's current
+        config. Cheap to construct (no I/O); we make a fresh one per
+        call so traitlet updates take effect immediately."""
+        return KCRealmAdmin(
+            self.httpfetch,
+            token_url=self.token_url,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            realm_api_url=self.realm_api_url,
+        )
 
 
 def configure(
@@ -206,14 +385,26 @@ def configure(
     callback_url: str,
     external_url: str,
     admin_groups=None,
+    realm_api_url: str = "",
+    shared_mount_role_name: str = "allow-group-directory-creation-role",
 ):
-    """Wire KeyCloakOAuthenticator onto JupyterHub's `c` config object."""
+    """Wire KeyCloakOAuthenticator onto JupyterHub's `c` config object.
+
+    ``realm_api_url`` enables role-gated shared-mount RBAC (issue #2304).
+    Pass the KC Admin API root for the realm
+    (e.g. ``https://kc.example/admin/realms/nebari``); leave empty to
+    disable. ``shared_mount_role_name`` is the KC client role whose
+    holders get ``/shared/<group>`` mounts — default matches classic
+    nebari.
+    """
     kc_config = KeyCloakConfig.build(
         issuer=issuer, post_logout_redirect_uri=external_url,
     )
     c.JupyterHub.authenticator_class = KeyCloakOAuthenticator
     c.KeyCloakOAuthenticator.client_id = client_id
     c.KeyCloakOAuthenticator.client_secret = client_secret
+    c.KeyCloakOAuthenticator.realm_api_url = realm_api_url
+    c.KeyCloakOAuthenticator.shared_mount_role_name = shared_mount_role_name
     c.KeyCloakOAuthenticator.oauth_callback_url = callback_url
     c.KeyCloakOAuthenticator.authorize_url = kc_config.authorize_url
     c.KeyCloakOAuthenticator.token_url = kc_config.token_url
@@ -269,6 +460,16 @@ except NameError:
 else:
     if os.environ.get("OAUTH_CALLBACK_URL"):
         _secret_dir = Path(os.environ.get("OAUTH_SECRET_DIR", "/etc/oauth"))
+        # RBAC for role-gated /shared/<group> mounts (issue #2304).
+        # Empty realm_api_url disables RBAC; the spawner falls back to
+        # the broader auth_state.groups list. Read via z2jh.get_config
+        # (the chart's convention for `custom.*` values) rather than
+        # env vars so the values flow through ``jupyterhub.custom`` in
+        # values.yaml exactly like every other deploy-time setting.
+        try:
+            from z2jh import get_config as _z2jh_get_config
+        except ImportError:
+            _z2jh_get_config = lambda k, default=None: default  # noqa: E731
         configure(
             c,  # noqa: F821
             issuer=_read_secret_file(_secret_dir, "issuer-url"),
@@ -276,4 +477,9 @@ else:
             client_secret=_read_secret_file(_secret_dir, "client-secret"),
             callback_url=os.environ["OAUTH_CALLBACK_URL"],
             external_url=os.environ["OAUTH_EXTERNAL_URL"],
+            realm_api_url=_z2jh_get_config("custom.rbac-realm-api-url", ""),
+            shared_mount_role_name=_z2jh_get_config(
+                "custom.rbac-shared-mount-role-name",
+                "allow-group-directory-creation-role",
+            ),
         )

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -526,8 +526,8 @@ def _get_user_groups(auth_state):
 
     Reads groups stored in auth_state by KeyCloakOAuthenticator (from
     Keycloak's IdToken `groups` claim). Applies the allowlist if
-    configured. Uses Path(g).name (last component) like classic Nebari so
-    /projects/myproj → myproj.
+    configured. Uses Path(g).name (last component) so KC groups like
+    /projects/myproj collapse to myproj.
     Deduplicates to prevent duplicate mountPath entries in the pod spec.
     Note: does NOT fall back to spawner.user.groups — accessing that SQLAlchemy
     relationship from an async hook causes DetachedInstanceError.
@@ -663,17 +663,55 @@ async def _setup_nss_wrapper(spawner, username, groups):
         f"printf '%s\\n' {etc_group!r} > /tmp/group",
     ]
 
+    # Group membership changes between spawns (gain, lose, swap) are a
+    # normal operational scenario. The home PVC persists, so the shape
+    # `~/shared` took on the LAST spawn is still there at the start of
+    # THIS spawn. We must reconcile WITHOUT touching user data: the
+    # only thing safe to delete unconditionally is a symlink, because
+    # the actual data it points at lives elsewhere (either on the RWX
+    # shared PVC mounted at /shared, or — in the chart's RWO-only
+    # fallback — in per-group dirs that the spawner mkdir-ed but never
+    # wiped). Real directories at ~/shared may hold user files; never
+    # blow them away.
+    #
+    #   groups + shared_storage_enabled: chart wants a symlink to /shared.
+    #     A prior real-dir at ~/shared (e.g. from an earlier
+    #     shared_storage=false spawn) would block `ln -sfn`. The dir's
+    #     contents are stale local placeholders — the live data is at
+    #     /shared/<group>. Safe to wipe the dir AND any prior symlink.
+    #
+    #   groups + !shared_storage_enabled: per-group local dirs live IN
+    #     the home PVC at ~/shared/<group>. Users may have written to
+    #     them. Preserve everything; just remove any pre-existing
+    #     symlink (left over from a shared_storage=true era) so the
+    #     subsequent `mkdir -p ~/shared` doesn't follow a dangling link.
+    #
+    #   no groups: the original failure mode — user lost group
+    #     membership, prior symlink to /shared dangles, `mkdir -p`
+    #     followed it and errored with "File exists" exit 1, kubelet
+    #     killed the container, CrashLoop. Fix: remove the symlink and
+    #     create nothing. Preserve any real dir (may hold the user's
+    #     last-known-good data from a previous shared_storage=false
+    #     spawn) so re-joining a group later sees it.
+    REMOVE_SYMLINK_ONLY = (
+        "[ -L /home/jovyan/shared ] && rm /home/jovyan/shared; true"
+    )
     if groups and shared_storage_enabled:
         log.debug("nss-wrapper: symlinking ~/shared → %s (PVC-backed)", shared_storage_mount_prefix)
+        # rm -rf is safe here: ~/shared is either a symlink (deletes
+        # only the link), an empty placeholder dir (no data), or stale
+        # per-group dirs whose live data is at /shared/<group>.
+        nss_cmds.append("rm -rf /home/jovyan/shared")
         nss_cmds.append(f"ln -sfn {shared_storage_mount_prefix} /home/jovyan/shared")
     elif groups:
         log.debug("nss-wrapper: creating local ~/shared/<group> dirs (no PVC): %s", groups)
+        nss_cmds.append(REMOVE_SYMLINK_ONLY)
         nss_cmds.append("mkdir -p /home/jovyan/shared")
         for group in groups:
             nss_cmds.append(f"mkdir -p /home/jovyan/shared/{group}")
     else:
-        log.debug("nss-wrapper: no groups — creating empty ~/shared dir")
-        nss_cmds.append("mkdir -p /home/jovyan/shared")
+        log.debug("nss-wrapper: no groups — clearing any stale symlink")
+        nss_cmds.append(REMOVE_SYMLINK_ONLY)
 
     # Merge into existing lifecycle_hooks rather than replacing, so other
     # hooks (e.g. from future jhub-apps versions) are not silently overwritten.

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -524,18 +524,37 @@ async def _nebi_pre_spawn_hook(spawner):
 def _get_user_groups(auth_state):
     """Extract and filter user groups from auth_state.
 
-    Reads groups stored in auth_state by KeyCloakOAuthenticator (from
-    Keycloak's IdToken `groups` claim). Applies the allowlist if
-    configured. Uses Path(g).name (last component) so KC groups like
-    /projects/myproj collapse to myproj.
-    Deduplicates to prevent duplicate mountPath entries in the pod spec.
-    Note: does NOT fall back to spawner.user.groups — accessing that SQLAlchemy
-    relationship from an async hook causes DetachedInstanceError.
+    Source priority:
+      1. ``auth_state["groups_with_permission_to_mount"]`` if present —
+         this is the role-gated subset stamped by KeyCloakOAuthenticator
+         when RBAC is enabled. Being in 10 KC groups should NOT mean
+         mounting 10 shared dirs; only those holding the
+         ``shared-directory-mount`` role on the hub client get to mount.
+      2. ``auth_state["groups"]`` — the user's full group list, used as
+         a fallback for clusters that have not yet deployed the RBAC
+         bootstrap (legacy / chart-default behaviour).
+
+    Then applies the chart's static allowlist, Path(g).name normalisation
+    (so /projects/myproj → myproj), and dedup.
+
+    Note: does NOT fall back to spawner.user.groups — accessing that
+    SQLAlchemy relationship from an async hook causes
+    DetachedInstanceError.
     """
     raw_groups = []
     if auth_state:
-        raw_groups = auth_state.get("groups", [])
-        log.debug("shared-storage: raw groups from auth_state: %s", raw_groups)
+        if "groups_with_permission_to_mount" in auth_state:
+            raw_groups = auth_state["groups_with_permission_to_mount"]
+            log.debug(
+                "shared-storage: role-gated groups from auth_state: %s",
+                raw_groups,
+            )
+        else:
+            raw_groups = auth_state.get("groups", [])
+            log.debug(
+                "shared-storage: fallback groups from auth_state (no RBAC filter): %s",
+                raw_groups,
+            )
     else:
         log.debug("shared-storage: no auth_state (DummyAuthenticator?), groups will be empty")
 

--- a/templates/keycloak-rbac-bootstrap-job.yaml
+++ b/templates/keycloak-rbac-bootstrap-job.yaml
@@ -28,7 +28,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    # Keep the Job around after success so its logs are inspectable.
+    # Delete only before a fresh hook fires (next install/upgrade).
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 2
@@ -63,6 +65,10 @@ spec:
             - -ec
             - |
               KC=/opt/keycloak/bin/kcadm.sh
+              # Trace every command + xtrace so a failed bootstrap shows
+              # up at the first non-zero step rather than several echoed
+              # warnings later.
+              set -x
               $KC config credentials --server "$KC_HOST" --realm master \
                 --user admin --password "$KC_ADMIN_PASSWORD" >/dev/null
 
@@ -120,45 +126,68 @@ spec:
               fi
 
               echo "==> 4. realm-management roles bound to hub client SA"
+              # Resolve realm-management client UUID and the hub
+              # client's SA user. The SA user only exists after
+              # ``serviceAccountsEnabled=true`` lands; the update
+              # above is synchronous in KC but defensively retry the
+              # SA lookup a few times before bailing.
               REALM_MGMT_UUID=$($KC get clients -r "$REALM" -q clientId=realm-management --fields id \
                 | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-              SA_USER_ID=$($KC get "clients/$HUB_UUID/service-account-user" -r "$REALM" \
-                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-              if [ -n "$REALM_MGMT_UUID" ] && [ -n "$SA_USER_ID" ]; then
-                for r in view-clients view-groups view-realm view-users; do
-                  ROLE_JSON=$($KC get "clients/$REALM_MGMT_UUID/roles/$r" -r "$REALM" 2>/dev/null || echo "")
-                  if [ -n "$ROLE_JSON" ]; then
-                    RID=$(echo "$ROLE_JSON" | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-                    RNAME=$(echo "$ROLE_JSON" | sed -n 's/.*"name" *: *"\([^"]*\)".*/\1/p' | head -1)
-                    $KC create "users/$SA_USER_ID/role-mappings/clients/$REALM_MGMT_UUID" -r "$REALM" \
-                      -b "[{\"id\":\"$RID\",\"name\":\"$RNAME\"}]" \
-                      || echo "  realm-management/$r may already be bound"
-                  fi
-                done
-              else
-                echo "  WARN: realm-management lookup failed; SA roles not bound"
+              SA_USER_ID=""
+              for _attempt in 1 2 3 4 5; do
+                SA_USER_ID=$($KC get "clients/$HUB_UUID/service-account-user" -r "$REALM" 2>/dev/null \
+                  | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+                [ -n "$SA_USER_ID" ] && break
+                sleep 2
+              done
+              if [ -z "$REALM_MGMT_UUID" ] || [ -z "$SA_USER_ID" ]; then
+                echo "  FATAL: realm-management ($REALM_MGMT_UUID) or hub SA ($SA_USER_ID) not resolvable"
+                exit 1
               fi
+              for r in view-clients view-groups view-realm view-users; do
+                RID=$($KC get "clients/$REALM_MGMT_UUID/roles/$r" -r "$REALM" 2>/dev/null \
+                  | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+                if [ -z "$RID" ]; then
+                  echo "  WARN: role realm-management/$r not found"
+                  continue
+                fi
+                # POST is idempotent in KC; duplicate grants 409. The
+                # || true keeps the loop running.
+                $KC create "users/$SA_USER_ID/role-mappings/clients/$REALM_MGMT_UUID" -r "$REALM" \
+                  -b "[{\"id\":\"$RID\",\"name\":\"$r\"}]" \
+                  || echo "  realm-management/$r already bound"
+              done
+              # Verify so the Job log shows the final state.
+              echo "  hub SA realm-management roles after binding:"
+              $KC get "users/$SA_USER_ID/role-mappings/clients/$REALM_MGMT_UUID" -r "$REALM" \
+                --fields name 2>&1 | head -20
 
               echo "==> 5. Assign shared-mount role to listed groups"
               if [ -n "$SHARED_MOUNT_GROUPS" ]; then
                 ROLE_JSON=$($KC get "clients/$HUB_UUID/roles/$ROLE_NAME" -r "$REALM")
                 RID=$(echo "$ROLE_JSON" | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-                IFS=,
-                for GROUP_PATH in $SHARED_MOUNT_GROUPS; do
-                  unset IFS
-                  GROUP_NAME=$(echo "$GROUP_PATH" | sed 's|^/||')
-                  GID=$($KC get groups -r "$REALM" -q search="$GROUP_NAME" --fields id,path \
-                    | sed -n "/\"path\" *: *\"$GROUP_PATH\"/,/^[},]/ s/.*\"id\" *: *\"\([^\"]*\)\".*/\1/p" | head -1)
+                # Comma-separated -> newline-separated so a single IFS=
+                # split works without leaking back into the loop body.
+                echo "$SHARED_MOUNT_GROUPS" | tr ',' '\n' | while IFS= read -r GROUP_PATH; do
+                  [ -z "$GROUP_PATH" ] && continue
+                  # KC's ``group-by-path`` endpoint returns the group
+                  # object directly — single JSON, stable field
+                  # ordering. Replaces the previous search-then-sed
+                  # approach which broke when the search-result JSON
+                  # listed id BEFORE path so the path-anchored sed
+                  # range couldn't capture id retroactively.
+                  GROUP_PATH_NO_LEAD=$(echo "$GROUP_PATH" | sed 's|^/||')
+                  GID=$($KC get "group-by-path/$GROUP_PATH_NO_LEAD" -r "$REALM" --fields id 2>/dev/null \
+                    | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
                   if [ -n "$GID" ]; then
+                    echo "  assigning $ROLE_NAME to group $GROUP_PATH (id=$GID)"
                     $KC create "groups/$GID/role-mappings/clients/$HUB_UUID" -r "$REALM" \
                       -b "[{\"id\":\"$RID\",\"name\":\"$ROLE_NAME\"}]" \
                       || echo "  group $GROUP_PATH already has role"
                   else
                     echo "  WARN: group $GROUP_PATH not found in realm; skipping"
                   fi
-                  IFS=,
                 done
-                unset IFS
               fi
 
               echo "==> rbac bootstrap done."

--- a/templates/keycloak-rbac-bootstrap-job.yaml
+++ b/templates/keycloak-rbac-bootstrap-job.yaml
@@ -19,6 +19,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "nebari-data-science-pack.fullname" . }}-rbac-bootstrap
+  {{- with .Values.rbac.bootstrap.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
   labels:
     {{- include "nebari-data-science-pack.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac-bootstrap
@@ -44,7 +47,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.rbac.bootstrap.kcAdminCredentialSecret | quote }}
-                  key: password
+                  key: {{ .Values.rbac.bootstrap.kcAdminCredentialSecretKey | default "password" | quote }}
             - name: REALM
               value: {{ .Values.rbac.bootstrap.realmName | quote }}
             - name: HUB_CLIENT_ID

--- a/templates/keycloak-rbac-bootstrap-job.yaml
+++ b/templates/keycloak-rbac-bootstrap-job.yaml
@@ -1,6 +1,6 @@
 {{/*
 One-shot Helm hook that provisions the Keycloak realm config the hub
-needs for role-gated shared-mount RBAC (Nebari issue #2304).
+needs for role-gated shared-mount RBAC.
 
 Runs on post-install AND post-upgrade so chart upgrades pick up newly
 added groups in ``rbac.bootstrap.sharedMountGroups``. Idempotent — every
@@ -55,7 +55,7 @@ spec:
             - name: HUB_CLIENT_ID
               value: {{ .Values.rbac.bootstrap.hubClientId | quote }}
             - name: ROLE_NAME
-              value: {{ index .Values.jupyterhub.custom "rbac-shared-mount-role-name" | quote }}
+              value: {{ .Values.rbac.bootstrap.sharedMountRoleName | quote }}
             - name: SHARED_MOUNT_GROUPS
               value: {{ .Values.rbac.bootstrap.sharedMountGroups | join "," | quote }}
             - name: KC_HOST

--- a/templates/keycloak-rbac-bootstrap-job.yaml
+++ b/templates/keycloak-rbac-bootstrap-job.yaml
@@ -1,0 +1,162 @@
+{{/*
+One-shot Helm hook that provisions the Keycloak realm config the hub
+needs for role-gated shared-mount RBAC (Nebari issue #2304).
+
+Runs on post-install AND post-upgrade so chart upgrades pick up newly
+added groups in ``rbac.bootstrap.sharedMountGroups``. Idempotent — every
+``kcadm create`` is followed by `|| true` and a "may already exist"
+log line so re-runs are clean.
+
+Skipped entirely when ``rbac.bootstrap.enabled`` is false OR when
+``rbac.bootstrap.kcAdminCredentialSecret`` is empty (chart deploys
+fine without RBAC pre-configured).
+*/}}
+{{- if and .Values.rbac.bootstrap.enabled .Values.rbac.bootstrap.kcAdminCredentialSecret }}
+{{- if not .Values.rbac.bootstrap.hubClientId }}
+{{- fail "rbac.bootstrap.hubClientId must be set when rbac.bootstrap.enabled=true — the role + SA bindings attach to this Keycloak client." }}
+{{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "nebari-data-science-pack.fullname" . }}-rbac-bootstrap
+  labels:
+    {{- include "nebari-data-science-pack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        {{- include "nebari-data-science-pack.labels" . | nindent 8 }}
+        app.kubernetes.io/component: rbac-bootstrap
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: kcadm
+          image: {{ .Values.rbac.bootstrap.image | quote }}
+          env:
+            - name: KC_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.rbac.bootstrap.kcAdminCredentialSecret | quote }}
+                  key: password
+            - name: REALM
+              value: {{ .Values.rbac.bootstrap.realmName | quote }}
+            - name: HUB_CLIENT_ID
+              value: {{ .Values.rbac.bootstrap.hubClientId | quote }}
+            - name: ROLE_NAME
+              value: {{ index .Values.jupyterhub.custom "rbac-shared-mount-role-name" | quote }}
+            - name: SHARED_MOUNT_GROUPS
+              value: {{ .Values.rbac.bootstrap.sharedMountGroups | join "," | quote }}
+            - name: KC_HOST
+              value: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080"
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              KC=/opt/keycloak/bin/kcadm.sh
+              $KC config credentials --server "$KC_HOST" --realm master \
+                --user admin --password "$KC_ADMIN_PASSWORD" >/dev/null
+
+              echo "==> 1. Group-Membership mapper on the 'groups' client scope"
+              SID=$($KC get client-scopes -r "$REALM" --fields id,name 2>/dev/null \
+                | grep -B1 '"name" *: *"groups"' \
+                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+              if [ -z "$SID" ]; then
+                echo "creating 'groups' client scope..."
+                $KC create client-scopes -r "$REALM" \
+                  -s name=groups \
+                  -s protocol=openid-connect \
+                  -s 'attributes={"include.in.token.scope":"true","display.on.consent.screen":"true"}' || true
+                SID=$($KC get client-scopes -r "$REALM" --fields id,name \
+                  | grep -B1 '"name" *: *"groups"' \
+                  | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+              fi
+              if [ -n "$SID" ]; then
+                if $KC get "client-scopes/$SID/protocol-mappers/models" -r "$REALM" \
+                    | grep -q '"name" *: *"group-membership"'; then
+                  echo "  mapper already present"
+                else
+                  echo "  adding oidc-group-membership-mapper to scope $SID"
+                  $KC create "client-scopes/$SID/protocol-mappers/models" -r "$REALM" \
+                    -s name=group-membership \
+                    -s protocol=openid-connect \
+                    -s protocolMapper=oidc-group-membership-mapper \
+                    -s 'config={"full.path":"true","introspection.token.claim":"true","userinfo.token.claim":"true","id.token.claim":"true","access.token.claim":"true","claim.name":"groups"}' \
+                    || echo "  mapper create returned non-zero — may have raced; continuing"
+                fi
+                $KC update "realms/$REALM/default-default-client-scopes/$SID" -r "$REALM" || true
+              else
+                echo "  WARN: groups client scope absent and could not be created"
+              fi
+
+              echo "==> 2. Hub OIDC client lookup + serviceAccountsEnabled"
+              HUB_UUID=$($KC get clients -r "$REALM" -q clientId=$HUB_CLIENT_ID --fields id \
+                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+              if [ -z "$HUB_UUID" ]; then
+                echo "FATAL: hub client $HUB_CLIENT_ID not found in realm $REALM"
+                exit 1
+              fi
+              $KC update "clients/$HUB_UUID" -r "$REALM" -s serviceAccountsEnabled=true || true
+
+              echo "==> 3. Shared-mount client role on hub client"
+              if $KC get "clients/$HUB_UUID/roles/$ROLE_NAME" -r "$REALM" >/dev/null 2>&1; then
+                echo "  role $ROLE_NAME already exists; ensuring attributes"
+                $KC update "clients/$HUB_UUID/roles/$ROLE_NAME" -r "$REALM" \
+                  -s 'attributes={"component":["shared-directory"],"scopes":["write:shared-mount"]}' || true
+              else
+                $KC create "clients/$HUB_UUID/roles" -r "$REALM" \
+                  -s name=$ROLE_NAME \
+                  -s 'attributes={"component":["shared-directory"],"scopes":["write:shared-mount"]}' \
+                  || echo "  role create returned non-zero — may have raced; continuing"
+              fi
+
+              echo "==> 4. realm-management roles bound to hub client SA"
+              REALM_MGMT_UUID=$($KC get clients -r "$REALM" -q clientId=realm-management --fields id \
+                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+              SA_USER_ID=$($KC get "clients/$HUB_UUID/service-account-user" -r "$REALM" \
+                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+              if [ -n "$REALM_MGMT_UUID" ] && [ -n "$SA_USER_ID" ]; then
+                for r in view-clients view-groups view-realm view-users; do
+                  ROLE_JSON=$($KC get "clients/$REALM_MGMT_UUID/roles/$r" -r "$REALM" 2>/dev/null || echo "")
+                  if [ -n "$ROLE_JSON" ]; then
+                    RID=$(echo "$ROLE_JSON" | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+                    RNAME=$(echo "$ROLE_JSON" | sed -n 's/.*"name" *: *"\([^"]*\)".*/\1/p' | head -1)
+                    $KC create "users/$SA_USER_ID/role-mappings/clients/$REALM_MGMT_UUID" -r "$REALM" \
+                      -b "[{\"id\":\"$RID\",\"name\":\"$RNAME\"}]" \
+                      || echo "  realm-management/$r may already be bound"
+                  fi
+                done
+              else
+                echo "  WARN: realm-management lookup failed; SA roles not bound"
+              fi
+
+              echo "==> 5. Assign shared-mount role to listed groups"
+              if [ -n "$SHARED_MOUNT_GROUPS" ]; then
+                ROLE_JSON=$($KC get "clients/$HUB_UUID/roles/$ROLE_NAME" -r "$REALM")
+                RID=$(echo "$ROLE_JSON" | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
+                IFS=,
+                for GROUP_PATH in $SHARED_MOUNT_GROUPS; do
+                  unset IFS
+                  GROUP_NAME=$(echo "$GROUP_PATH" | sed 's|^/||')
+                  GID=$($KC get groups -r "$REALM" -q search="$GROUP_NAME" --fields id,path \
+                    | sed -n "/\"path\" *: *\"$GROUP_PATH\"/,/^[},]/ s/.*\"id\" *: *\"\([^\"]*\)\".*/\1/p" | head -1)
+                  if [ -n "$GID" ]; then
+                    $KC create "groups/$GID/role-mappings/clients/$HUB_UUID" -r "$REALM" \
+                      -b "[{\"id\":\"$RID\",\"name\":\"$ROLE_NAME\"}]" \
+                      || echo "  group $GROUP_PATH already has role"
+                  else
+                    echo "  WARN: group $GROUP_PATH not found in realm; skipping"
+                  fi
+                  IFS=,
+                done
+                unset IFS
+              fi
+
+              echo "==> rbac bootstrap done."
+{{- end }}

--- a/tests/unit/test_nss_wrapper_shared_dir.py
+++ b/tests/unit/test_nss_wrapper_shared_dir.py
@@ -1,0 +1,156 @@
+"""Tests for the `~/shared` lifecycle in `_setup_nss_wrapper`.
+
+Group membership changes between spawns are a normal operational scenario:
+admins add/remove users from KC groups, users self-leave projects, etc.
+The home PVC is persistent across spawns, so whatever shape `~/shared`
+took on the LAST spawn is still there at the START of the next spawn.
+
+Three transitions matter:
+
+  1. user had groups (← `~/shared` is a symlink to `/shared`)
+     then user has no groups (`/shared` is NOT mounted)
+     → `mkdir -p /home/jovyan/shared` follows the symlink, the target
+       `/shared` doesn't exist as an accessible directory, mkdir errors
+       with "File exists" exit 1, postStart fails, kubelet kills the
+       container, CrashLoop.
+
+  2. user had no groups (`~/shared` is a real empty dir)
+     then user has groups (chart wants a symlink)
+     → `ln -sfn /shared /home/jovyan/shared` cannot replace an existing
+       directory; symlink creation fails silently and the user can't see
+       the shared mount.
+
+  3. shared-storage flipped off in chart values between spawns
+     → symlink still in PVC, target unmounted, same as case (1).
+
+The fix reconciles ~/shared per branch with data-safety in mind:
+
+  * groups + shared_storage: `rm -rf` then `ln -sfn` — safe because
+    real data is on the RWX PVC at /shared/<group>, ~/shared is only
+    ever a pointer.
+  * groups + no shared_storage (RWO fallback): symlink-only rm, then
+    `mkdir -p` for per-group dirs. The per-group dirs in the home PVC
+    MAY hold user files, so preserve them.
+  * no groups: symlink-only rm, no mkdir. Leaving ~/shared absent lets
+    the next groups-gained spawn's `ln -sfn` work cleanly.
+
+This module pins that contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+# 01-spawner.py imports z2jh.get_config; stub it like the storage test does.
+_z2jh = types.ModuleType("z2jh")
+_z2jh.get_config = lambda key, default=None: default
+sys.modules.setdefault("z2jh", _z2jh)
+
+from conftest import FakeConfig, load_config_module  # noqa: E402
+
+
+class FakeSpawner:
+    """Records the bits `_setup_nss_wrapper` mutates."""
+
+    def __init__(self):
+        self.environment = {}
+        self.lifecycle_hooks = None
+
+
+def _load_spawner_module(shared_storage_enabled: bool):
+    c = FakeConfig()
+    # Drive the module-level `shared_storage_enabled` global via the
+    # custom.shared-storage-enabled chart config.
+    custom = {
+        "custom.shared-storage-enabled": shared_storage_enabled,
+        "custom.shared-storage-groups": [],
+        "custom.shared-storage-mount-prefix": "/shared",
+        "custom.storage-capacity": "20Gi",
+    }
+    z2jh = sys.modules["z2jh"]
+    z2jh.get_config = lambda key, default=None: custom.get(key, default)
+    return load_config_module("01-spawner.py", inject_c=c)
+
+
+def _poststart_cmd(spawner: FakeSpawner) -> str:
+    """Extract the joined sh -c command string from the registered hook."""
+    cmd_list = spawner.lifecycle_hooks["postStart"]["exec"]["command"]
+    assert cmd_list[:2] == ["/bin/sh", "-c"]
+    return cmd_list[2]
+
+
+def test_no_groups_removes_dangling_symlink_without_destroying_real_dir():
+    """User lost group membership. Prior shared_storage=true spawn left a
+    symlink at ~/shared → /shared; /shared is no longer mounted, the
+    symlink dangles. The previous implementation ran `mkdir -p ~/shared`
+    which follows the symlink and errors with `File exists` exit 1,
+    crashing the container. Fix: symlink-only rm. Must NOT use `rm -rf`
+    here, because a real directory may hold user data from a prior
+    shared_storage=false spawn — preserve it for the next groups-gained
+    spawn."""
+    mod = _load_spawner_module(shared_storage_enabled=True)
+    spawner = FakeSpawner()
+    asyncio.run(mod._setup_nss_wrapper(spawner, "alice@example.test", groups=[]))
+
+    cmd = _poststart_cmd(spawner)
+    assert "[ -L /home/jovyan/shared ]" in cmd and "rm /home/jovyan/shared" in cmd, (
+        f"no-groups branch must symlink-test then rm to clear a "
+        f"dangling pointer; got: {cmd!r}"
+    )
+    assert "rm -rf /home/jovyan/shared" not in cmd, (
+        f"no-groups branch must NOT `rm -rf` — would wipe a real dir "
+        f"holding user data from a prior shared_storage=false spawn; "
+        f"got: {cmd!r}"
+    )
+    assert "mkdir -p /home/jovyan/shared" not in cmd, (
+        f"no-groups branch must not recreate ~/shared — leaving nothing "
+        f"lets the next groups-gained spawn's `ln -sfn` create a clean "
+        f"symlink with no dance; got: {cmd!r}"
+    )
+
+
+def test_groups_with_shared_storage_wipes_prior_state_then_symlinks():
+    """User has groups + chart has shared_storage. ~/shared must be a
+    symlink to /shared. Any prior state (symlink, empty placeholder, or
+    stale per-group dirs from a previous shared_storage=false spawn) is
+    safe to wipe — the live data lives at /shared/<group> on the RWX
+    PVC, not in the home PVC. `ln -sfn` cannot replace a directory, so
+    `rm -rf` first."""
+    mod = _load_spawner_module(shared_storage_enabled=True)
+    spawner = FakeSpawner()
+    asyncio.run(mod._setup_nss_wrapper(
+        spawner, "alice@example.test", groups=["data"],
+    ))
+
+    cmd = _poststart_cmd(spawner)
+    assert "rm -rf /home/jovyan/shared" in cmd
+    assert "ln -sfn /shared /home/jovyan/shared" in cmd
+    assert cmd.index("rm -rf /home/jovyan/shared") < cmd.index(
+        "ln -sfn /shared /home/jovyan/shared"
+    ), f"rm must come before ln so the symlink can be created; got: {cmd!r}"
+
+
+def test_groups_without_shared_storage_preserves_user_data_in_per_group_dirs():
+    """RWO-only fallback: groups present, no shared PVC. The chart
+    creates ~/shared/<group> as REAL DIRECTORIES inside the home PVC
+    and users may have written files into them across past spawns.
+    Must NOT `rm -rf` ~/shared (would wipe user data). Just clear a
+    pre-existing symlink (left by a prior shared_storage=true era) so
+    the subsequent mkdir doesn't follow it."""
+    mod = _load_spawner_module(shared_storage_enabled=False)
+    spawner = FakeSpawner()
+    asyncio.run(mod._setup_nss_wrapper(
+        spawner, "alice@example.test", groups=["data", "ml"],
+    ))
+
+    cmd = _poststart_cmd(spawner)
+    assert "rm -rf /home/jovyan/shared" not in cmd, (
+        f"RWO fallback must preserve user data in ~/shared/<group>; "
+        f"got: {cmd!r}"
+    )
+    assert "[ -L /home/jovyan/shared ]" in cmd and "rm /home/jovyan/shared" in cmd
+    assert "mkdir -p /home/jovyan/shared" in cmd
+    assert "mkdir -p /home/jovyan/shared/data" in cmd
+    assert "mkdir -p /home/jovyan/shared/ml" in cmd

--- a/tests/unit/test_rbac_shared_mount.py
+++ b/tests/unit/test_rbac_shared_mount.py
@@ -12,8 +12,7 @@ Public contract (chart-side):
   The role is identified by:
     * configurable role name (default: ``shared-directory-mount``)
     * fixed attribute pair ``component=shared-directory``,
-      ``scopes=write:shared-mount`` (mirrors classic nebari so realm-
-      setup tooling can be shared)
+      ``scopes=write:shared-mount``
 
   When the realm-admin path is unavailable (KC down, no permissions,
   service-account misconfigured), the user STILL logs in — they just
@@ -434,9 +433,9 @@ def test_refresh_user_skips_rbac_when_realm_api_url_empty():
 def test_configure_propagates_realm_api_url_and_role_name():
     """The chart's configure() entrypoint must accept realm_api_url +
     shared_mount_role_name and set them so the authenticator's
-    update_auth_model knows where to call. Default role name should
-    match classic nebari ('allow-group-directory-creation-role') so a
-    realm provisioned by the classic playbook works out of the box."""
+    update_auth_model knows where to call. Default role name
+    ``allow-group-directory-creation-role`` is the stable identifier
+    realm-setup tooling expects."""
     c = ga.KeyCloakOAuthenticator.kc_config  # may be stale from earlier tests
     # Build a FakeConfig-like object: namespace per traitlets class.
     cfg = types.SimpleNamespace(

--- a/tests/unit/test_rbac_shared_mount.py
+++ b/tests/unit/test_rbac_shared_mount.py
@@ -1,0 +1,484 @@
+"""Tests for role-gated shared-directory mounting.
+
+Public contract (chart-side):
+
+  After a user authenticates, ``auth_state["groups_with_permission_to_mount"]``
+  lists exactly the KC groups that BOTH (a) the user belongs to AND (b)
+  hold a specific role on the hub's KC client. The chart's spawner reads
+  this list to decide which /shared/<group> dirs to mount — being in a
+  KC group is necessary but not sufficient, the group also has to be
+  granted the mount permission.
+
+  The role is identified by:
+    * configurable role name (default: ``shared-directory-mount``)
+    * fixed attribute pair ``component=shared-directory``,
+      ``scopes=write:shared-mount`` (mirrors classic nebari so realm-
+      setup tooling can be shared)
+
+  When the realm-admin path is unavailable (KC down, no permissions,
+  service-account misconfigured), the user STILL logs in — they just
+  see no shared mounts. Login MUST NOT fail because of realm-admin
+  problems.
+
+These tests drive the authenticator's public ``update_auth_model``
+through the JupyterHub contract with the KC Admin API mocked at the HTTP
+boundary (``httpfetch``). They do not rely on internal helpers — any
+refactor that preserves the observable auth_model contents passes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+from tornado.httpclient import HTTPClientError, HTTPRequest, HTTPResponse
+
+# 00-gateway-auth.py imports cleanly without a chart `c` config object.
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "config" / "jupyterhub" / "00-gateway-auth.py"
+spec = importlib.util.spec_from_file_location("_gateway_auth", MODULE_PATH)
+ga = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ga)
+
+
+HUB_CLIENT_ID = "jupyterhub-data-science-pack-nebari-data-science-pack"
+HUB_CLIENT_UUID = "53008075-f97e-4efb-8b8b-03c1d13f054a"
+REALM_API = "https://kc.example.test/admin/realms/nebari"
+TOKEN_URL = "https://kc.example.test/realms/nebari/protocol/openid-connect/token"
+SHARED_MOUNT_ROLE = "allow-group-directory-creation-role"
+
+
+def _kc_role_payload(name=SHARED_MOUNT_ROLE):
+    """The exact shape KC's `GET clients/{id}/roles/{name}` returns for a
+    rich role with the shared-directory component + write:shared-mount
+    scope. Captured from a real kcadm dump."""
+    return {
+        "id": "00000000-aaaa-bbbb-cccc-000000000001",
+        "name": name,
+        "description": "",
+        "composite": False,
+        "clientRole": True,
+        "containerId": HUB_CLIENT_UUID,
+        "attributes": {
+            "component": ["shared-directory"],
+            "scopes": ["write:shared-mount"],
+        },
+    }
+
+
+def _make_authenticator(**overrides):
+    auth = ga.KeyCloakOAuthenticator()
+    auth.token_url = TOKEN_URL
+    auth.client_id = HUB_CLIENT_ID
+    auth.client_secret = "sek"
+    # New traitlets introduced by this PR. Test sets them like configure() would.
+    auth.realm_api_url = REALM_API
+    auth.shared_mount_role_name = SHARED_MOUNT_ROLE
+    for k, v in overrides.items():
+        setattr(auth, k, v)
+    return auth
+
+
+def _kc_admin_api_dispatch(role_groups, role_payload=None):
+    """Build an httpfetch side-effect that mimics KC's HTTP responses.
+
+    role_groups -- list of {"name":"admin","path":"/admin"} dicts the
+                   role assigns to.
+    role_payload -- override role JSON (use to test missing attrs).
+    """
+    payload = role_payload if role_payload is not None else _kc_role_payload()
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        # client_credentials grant
+        if url == TOKEN_URL and method == "POST":
+            assert "grant_type=client_credentials" in body, (
+                f"expected client_credentials grant for realm-admin token, got body={body!r}"
+            )
+            return {"access_token": "admin-bearer-xxx", "expires_in": 60}
+        # clients lookup by clientId
+        if url.startswith(f"{REALM_API}/clients?clientId="):
+            assert HUB_CLIENT_ID in url
+            return [{"id": HUB_CLIENT_UUID, "clientId": HUB_CLIENT_ID}]
+        # role fetch
+        if url == f"{REALM_API}/clients/{HUB_CLIENT_UUID}/roles/{SHARED_MOUNT_ROLE}":
+            return payload
+        # groups holding role
+        if url == f"{REALM_API}/clients/{HUB_CLIENT_UUID}/roles/{SHARED_MOUNT_ROLE}/groups":
+            return role_groups
+        raise AssertionError(f"unexpected httpfetch call: {method} {url}")
+
+    return fetch
+
+
+def _auth_model_for(user_groups):
+    """A baseline auth_model dict the way oauthenticator builds one."""
+    return {
+        "name": "alice",
+        "admin": False,
+        "auth_state": {
+            "access_token": "user-at",
+            "refresh_token": "user-rt",
+            "id_token": "user-id",
+            "scope": "openid groups",
+            "token_response": {},
+            "oauth_user": {
+                "preferred_username": "alice",
+                "groups": user_groups,
+            },
+        },
+    }
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Tracer bullet: end-to-end role → groups_with_permission_to_mount
+# ---------------------------------------------------------------------------
+
+def test_groups_with_permission_to_mount_is_user_groups_intersect_role_groups():
+    """User in [/admin, /data]. Role 'shared-directory-mount' assigned only
+    to /admin. Result should expose ONLY /admin in
+    auth_state['groups_with_permission_to_mount'] — the intersection,
+    not the union, and not the user's full group list.
+
+    This is the saga's core requirement: being in 10 KC groups does NOT
+    mean mounting 10 shared dirs. Only the groups that explicitly hold
+    the shared-directory role get mounted."""
+    auth = _make_authenticator()
+    auth.httpfetch = AsyncMock(side_effect=_kc_admin_api_dispatch(
+        role_groups=[{"name": "admin", "path": "/admin"}],
+    ))
+    am = _auth_model_for(user_groups=["/admin", "/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["groups_with_permission_to_mount"] == ["/admin"], (
+        f"expected only /admin (intersection of user groups and role-holders); "
+        f"got {out['auth_state'].get('groups_with_permission_to_mount')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spawner consumes the filtered set
+# ---------------------------------------------------------------------------
+
+def _load_spawner_module(custom=None):
+    """Load 01-spawner.py with a z2jh stub; returns the module."""
+    z = types.ModuleType("z2jh")
+    cfg = {
+        "custom.shared-storage-enabled": True,
+        "custom.shared-storage-groups": [],
+        "custom.shared-storage-mount-prefix": "/shared",
+        "custom.storage-capacity": "20Gi",
+        **(custom or {}),
+    }
+    z.get_config = lambda k, default=None: cfg.get(k, default)
+    sys.modules["z2jh"] = z
+    sp_spec = importlib.util.spec_from_file_location(
+        "_spawner", REPO_ROOT / "config" / "jupyterhub" / "01-spawner.py",
+    )
+    sp = importlib.util.module_from_spec(sp_spec)
+    sp.__dict__["c"] = _ChartConfig()  # bare FakeConfig stand-in
+    sp_spec.loader.exec_module(sp)
+    return sp
+
+
+class _ChartConfig:
+    """Minimal stand-in for JupyterHub's `c`. Records assignments; serves
+    fresh sub-namespaces on attribute access so `c.KubeSpawner.x = y`
+    works without raising. Real value of `c.KubeSpawner.volumes` etc. is
+    irrelevant to these tests — they only inspect what the SPAWNER FUNCTION
+    returns or stores on its argument."""
+
+    def __getattr__(self, name):
+        ns = types.SimpleNamespace(
+            init_containers=[], volumes=[], volume_mounts=[],
+            environment={}, extra_pod_config={},
+        )
+        self.__dict__[name] = ns
+        return ns
+
+
+def test_spawner_uses_groups_with_permission_to_mount_when_present():
+    """The spawner must prefer auth_state['groups_with_permission_to_mount']
+    over the broader auth_state['groups'] list. Being in 10 KC groups
+    does NOT mean mounting 10 shared dirs — only the groups with the
+    shared-mount role get mounted."""
+    sp = _load_spawner_module()
+    auth_state = {
+        "groups": ["/admin", "/data", "/random"],
+        "groups_with_permission_to_mount": ["/admin"],
+    }
+    groups = sp._get_user_groups(auth_state)
+    assert groups == ["admin"], (
+        f"expected only [admin] (the role-gated subset); got {groups!r}. "
+        "auth_state['groups'] should not leak into the mount decision."
+    )
+
+
+def test_spawner_falls_back_to_groups_when_filter_not_set():
+    """When auth_state has no 'groups_with_permission_to_mount' key
+    (RBAC disabled, legacy auth_state, KC Admin API unreachable on this
+    login), fall back to auth_state['groups'] — the chart still works
+    on clusters that haven't deployed the RBAC bootstrap yet."""
+    sp = _load_spawner_module()
+    auth_state = {"groups": ["/admin", "/data"]}
+    groups = sp._get_user_groups(auth_state)
+    assert sorted(groups) == ["admin", "data"]
+
+
+def test_spawner_filter_normalises_paths_and_dedups():
+    """The filtered set should still go through Path(g).name normalisation
+    and dedup — `/projects/myproj` collapses to `myproj`, duplicates
+    drop. Pre-existing contract, must survive."""
+    sp = _load_spawner_module()
+    auth_state = {
+        "groups_with_permission_to_mount": [
+            "/projects/myproj", "/projects/myproj", "/data",
+        ],
+    }
+    assert sorted(sp._get_user_groups(auth_state)) == ["data", "myproj"]
+
+
+# ---------------------------------------------------------------------------
+# KC Admin API failures degrade — login must still succeed
+# ---------------------------------------------------------------------------
+
+def _http_error(code, body=b""):
+    from io import BytesIO
+    fake_req = HTTPRequest("https://kc.test")
+    fake_resp = HTTPResponse(fake_req, code, buffer=BytesIO(body))
+    return HTTPClientError(code, f"HTTP {code}", fake_resp)
+
+
+def test_admin_api_5xx_does_not_break_login():
+    """If KC Admin API is unreachable / 5xx, the user must still log in.
+    auth_state['groups_with_permission_to_mount'] is set to [] and a
+    WARNING is logged. update_auth_model MUST NOT raise."""
+    auth = _make_authenticator()
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        if url == TOKEN_URL:
+            return {"access_token": "admin-bearer-xxx"}
+        raise _http_error(503, b'{"error":"upstream"}')
+
+    auth.httpfetch = AsyncMock(side_effect=fetch)
+    am = _auth_model_for(user_groups=["/admin", "/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["groups_with_permission_to_mount"] == []
+    assert out["name"] == "alice"  # login itself succeeded
+
+
+def test_oauth_client_not_a_service_account_does_not_break_login():
+    """Realistic failure mode: the OAuth client doesn't have
+    serviceAccountsEnabled=true (operator hasn't been updated) or lacks
+    realm-management roles. client_credentials grant 401s. Login still
+    succeeds; filter is empty; WARNING logged."""
+    auth = _make_authenticator()
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        if url == TOKEN_URL:
+            raise _http_error(401, b'{"error":"unauthorized_client"}')
+        raise AssertionError("should not have reached Admin API without a token")
+
+    auth.httpfetch = AsyncMock(side_effect=fetch)
+    am = _auth_model_for(user_groups=["/admin"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["groups_with_permission_to_mount"] == []
+    assert out["name"] == "alice"
+
+
+def test_role_missing_attributes_returns_empty_filter():
+    """KC role exists but is missing the component / scopes attributes
+    (deployer created the role manually without the right metadata).
+    Treat as 'no groups can mount' — safer to grant nothing than to
+    grant all groups."""
+    auth = _make_authenticator()
+    bad_payload = dict(_kc_role_payload())
+    bad_payload["attributes"] = {}
+    auth.httpfetch = AsyncMock(side_effect=_kc_admin_api_dispatch(
+        role_groups=[{"name": "admin", "path": "/admin"}],
+        role_payload=bad_payload,
+    ))
+    am = _auth_model_for(user_groups=["/admin"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["groups_with_permission_to_mount"] == []
+
+
+def test_realm_api_url_empty_skips_filter_entirely():
+    """When realm_api_url is empty (chart deployed with rbac disabled,
+    or operator hasn't surfaced the URL yet), update_auth_model must
+    not call the Admin API at all and must not set the filter key —
+    spawner's fallback to auth_state['groups'] kicks in."""
+    auth = _make_authenticator(realm_api_url="")
+    auth.httpfetch = AsyncMock(side_effect=AssertionError(
+        "httpfetch must not be called when realm_api_url is empty"
+    ))
+    am = _auth_model_for(user_groups=["/admin"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert "groups_with_permission_to_mount" not in out["auth_state"], (
+        f"expected key absent when RBAC disabled; got "
+        f"{out['auth_state'].get('groups_with_permission_to_mount')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# refresh_user re-runs the filter (KC role changes take effect mid-session)
+# ---------------------------------------------------------------------------
+
+class _FakeUser:
+    def __init__(self, name, auth_state):
+        self.name = name
+        self._auth_state = auth_state
+
+    async def get_auth_state(self):
+        return self._auth_state
+
+
+def test_refresh_user_recomputes_groups_with_permission_to_mount():
+    """A user's KC role assignments change mid-session (admin adds them
+    to /developer and grants the developer group the shared-mount role).
+    The next refresh_user cycle (default every 240s) must re-evaluate
+    auth_state['groups_with_permission_to_mount'] so the *next* spawn
+    in this session picks up the new mount — no force-relogin required.
+    """
+    auth = _make_authenticator()
+    # auth_state before refresh: user already had /admin, no developer yet.
+    user = _FakeUser("alice", {
+        "access_token": "old-at",
+        "refresh_token": "old-rt",
+        "id_token": "old-id",
+        "oauth_user": {
+            "preferred_username": "alice",
+            "groups": ["/admin", "/developer"],  # KC just added developer
+        },
+    })
+    # KC state at refresh time: now /developer ALSO holds the role.
+    role_groups_at_refresh = [
+        {"name": "admin", "path": "/admin"},
+        {"name": "developer", "path": "/developer"},
+    ]
+    base_admin_dispatch = _kc_admin_api_dispatch(role_groups=role_groups_at_refresh)
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        # refresh_token grant
+        if url == TOKEN_URL and method == "POST" and "refresh_token" in (body or ""):
+            return {
+                "access_token": "new-at",
+                "refresh_token": "new-rt",
+                "id_token": "new-id",
+                "expires_in": 300,
+            }
+        # otherwise it's the admin-token + Admin API path
+        return await base_admin_dispatch(url, method=method, headers=headers, body=body)
+
+    auth.httpfetch = AsyncMock(side_effect=fetch)
+
+    result = _run(auth.refresh_user(user))
+
+    assert isinstance(result, dict), f"refresh_user must return a dict; got {result!r}"
+    new_state = result["auth_state"]
+    assert new_state["access_token"] == "new-at", "token rotation still works"
+    assert new_state["groups_with_permission_to_mount"] == ["/admin", "/developer"], (
+        f"refresh_user must re-evaluate the role-gated filter against current "
+        f"KC state; got {new_state.get('groups_with_permission_to_mount')!r}"
+    )
+
+
+def test_refresh_user_skips_rbac_when_realm_api_url_empty():
+    """RBAC disabled at the chart level: refresh_user is a pure token
+    refresh, does not touch the Admin API, and does NOT write a
+    groups_with_permission_to_mount key into auth_state."""
+    auth = _make_authenticator(realm_api_url="")
+    user = _FakeUser("alice", {
+        "access_token": "old-at",
+        "refresh_token": "old-rt",
+        "oauth_user": {"preferred_username": "alice", "groups": ["/admin"]},
+    })
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        # only the refresh-token grant should fire
+        assert url == TOKEN_URL and "refresh_token" in (body or ""), (
+            f"realm_api_url empty must mean no Admin API call; got {method} {url}"
+        )
+        return {"access_token": "new-at", "refresh_token": "new-rt"}
+
+    auth.httpfetch = AsyncMock(side_effect=fetch)
+    result = _run(auth.refresh_user(user))
+
+    assert isinstance(result, dict)
+    assert "groups_with_permission_to_mount" not in result["auth_state"]
+
+
+# ---------------------------------------------------------------------------
+# configure() wires the chart's RBAC values onto the authenticator
+# ---------------------------------------------------------------------------
+
+def test_configure_propagates_realm_api_url_and_role_name():
+    """The chart's configure() entrypoint must accept realm_api_url +
+    shared_mount_role_name and set them so the authenticator's
+    update_auth_model knows where to call. Default role name should
+    match classic nebari ('allow-group-directory-creation-role') so a
+    realm provisioned by the classic playbook works out of the box."""
+    c = ga.KeyCloakOAuthenticator.kc_config  # may be stale from earlier tests
+    # Build a FakeConfig-like object: namespace per traitlets class.
+    cfg = types.SimpleNamespace(
+        JupyterHub=types.SimpleNamespace(),
+        KeyCloakOAuthenticator=types.SimpleNamespace(),
+        Authenticator=types.SimpleNamespace(),
+    )
+    ga.configure(
+        cfg,
+        issuer="https://kc.example/realms/nebari",
+        client_id="hub-client",
+        client_secret="sek",
+        callback_url="https://hub.example/hub/oauth_callback",
+        external_url="https://hub.example/",
+        realm_api_url="https://kc.example/admin/realms/nebari",
+    )
+
+    assert cfg.KeyCloakOAuthenticator.realm_api_url == (
+        "https://kc.example/admin/realms/nebari"
+    )
+    assert cfg.KeyCloakOAuthenticator.shared_mount_role_name == (
+        "allow-group-directory-creation-role"
+    )
+
+
+def test_configure_defaults_rbac_off_when_realm_api_url_unset():
+    """Backwards-compat: configure() callers that don't pass realm_api_url
+    get RBAC disabled — the chart works for deployers who haven't
+    enabled the bootstrap Job yet. update_auth_model returns without
+    touching the Admin API."""
+    cfg = types.SimpleNamespace(
+        JupyterHub=types.SimpleNamespace(),
+        KeyCloakOAuthenticator=types.SimpleNamespace(),
+        Authenticator=types.SimpleNamespace(),
+    )
+    ga.configure(
+        cfg,
+        issuer="https://kc.example/realms/nebari",
+        client_id="hub-client",
+        client_secret="sek",
+        callback_url="https://hub.example/hub/oauth_callback",
+        external_url="https://hub.example/",
+    )
+    # Empty string is the documented "RBAC disabled" sentinel.
+    assert cfg.KeyCloakOAuthenticator.realm_api_url == ""

--- a/tests/unit/test_refresh_user.py
+++ b/tests/unit/test_refresh_user.py
@@ -61,7 +61,12 @@ def auth():
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # `asyncio.get_event_loop()` is deprecated since 3.10 and raises in
+    # 3.12+ once any other test in the same process has called
+    # `asyncio.run` (which creates + closes a fresh loop, leaving the
+    # thread with no current loop). `asyncio.run` is the supported
+    # pattern for sync test bodies.
+    return asyncio.run(coro)
 
 
 def test_refresh_user_returns_updated_auth_state_on_success(auth):

--- a/values.yaml
+++ b/values.yaml
@@ -241,20 +241,23 @@ jupyterhub:
     shared-storage-enabled: false
     shared-storage-groups: []       # allowlist; empty = all groups from token
     shared-storage-mount-prefix: "/shared"
-    # Role-gated shared-mount RBAC (Nebari issue #2304).
-    # When ``rbac-realm-api-url`` is set, the hub calls KC's Admin API
-    # on every login + refresh to find which of the user's KC groups
-    # hold ``rbac-shared-mount-role-name`` on the hub OIDC client.
-    # The spawner then mounts only ``/shared/<group>`` for that
-    # filtered subset. Empty URL = RBAC disabled = spawner falls back
-    # to mounting every group the user is in (legacy behaviour).
+    # Role-gated shared-mount RBAC (Nebari issue #2304) configuration
+    # is delivered via the hub Deployment's env vars (KC_REALM_API_URL
+    # + KC_SHARED_MOUNT_ROLE), NOT via this `custom` block. Reasons:
+    #   * `custom.*` is rendered into the z2jh Secret's embedded
+    #     values.yaml. Several rotating fields in that Secret are
+    #     pinned via Argo `ignoreDifferences` to stop the
+    #     auth_token/cookie_secret churn — and broad ignore on
+    #     ``/data`` silently swallows config changes here.
+    #   * The hub Deployment's env vars flow through SSA + the
+    #     existing checksum-driven hub rollout cleanly.
     #
-    # KC requirements: the hub OAuth client needs
-    # ``serviceAccountsEnabled=true`` and realm-management roles
-    # (view-clients, view-groups, view-realm) bound to its SA. The
-    # chart's ``rbac.bootstrap`` Helm Job provisions this.
-    rbac-realm-api-url: ""
-    rbac-shared-mount-role-name: "allow-group-directory-creation-role"
+    # Set in the deployer's overlay under
+    # ``jupyterhub.hub.extraEnv.KC_REALM_API_URL``. Empty = RBAC off,
+    # spawner falls back to mounting every group the user is in
+    # (legacy behaviour). KC requirements (serviceAccountsEnabled,
+    # realm-management roles, the shared-directory role with attrs)
+    # are provisioned by the chart's ``rbac.bootstrap`` Helm Job.
     # jhub-apps (JAppsConfig) overrides.
     # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
     # See https://jhub-apps.nebari.dev/docs/configuration for available options.

--- a/values.yaml
+++ b/values.yaml
@@ -192,10 +192,18 @@ nebi:
 rbac:
   bootstrap:
     enabled: false
+    # Namespace to run the Job in. Default (empty) = chart release
+    # namespace. Override to the keycloak namespace so the Job can
+    # read the admin-credentials Secret without cross-namespace copy.
+    namespace: ""
     # Name of a K8s Secret holding the KC realm-admin password in key
     # ``password``. Job authenticates as ``admin`` in the ``master``
     # realm via kcadm.sh and applies config to ``realmName``.
     kcAdminCredentialSecret: ""
+    # Key within ``kcAdminCredentialSecret`` that holds the password.
+    # Default ``admin-password`` matches the bitnami keycloak/keycloakx
+    # chart's ``keycloak-admin-credentials`` Secret layout.
+    kcAdminCredentialSecretKey: "admin-password"
     # Realm to bootstrap.
     realmName: "nebari"
     # ClientId of the hub OAuth client in Keycloak (created by the

--- a/values.yaml
+++ b/values.yaml
@@ -179,8 +179,7 @@ nebi:
 #   2. Creates the ``allow-group-directory-creation-role`` client
 #      role on the hub OIDC client with attributes
 #      ``component=shared-directory`` and
-#      ``scopes=write:shared-mount`` (same role classic nebari
-#      provisions).
+#      ``scopes=write:shared-mount``.
 #   3. Grants the hub client ``serviceAccountsEnabled=true`` and
 #      binds ``realm-management.{view-clients,view-groups,view-realm}``
 #      to its service account.

--- a/values.yaml
+++ b/values.yaml
@@ -167,7 +167,7 @@ nebi:
   port: 8460
 
 # Helm Job that one-shots Keycloak realm config for role-gated shared
-# mounts (Nebari issue #2304). Runs as a post-install / post-upgrade
+# mounts. Runs as a post-install / post-upgrade
 # hook. Idempotent; skips cleanly if ``kcAdminCredentialSecret`` is
 # unset, so the chart can install on clusters that haven't yet
 # surfaced an admin credential.
@@ -208,6 +208,10 @@ rbac:
     # ClientId of the hub OAuth client in Keycloak (created by the
     # nebari-operator NebariApp). The role + SA roles attach here.
     hubClientId: ""
+    # Name of the client role the Job creates on the hub OIDC client.
+    # Must match ``KC_SHARED_MOUNT_ROLE`` env var on the hub Deployment
+    # (defaults align).
+    sharedMountRoleName: "allow-group-directory-creation-role"
     # KC group paths to assign the shared-mount role to. Each path
     # must already exist in KC. e.g.
     #   - /admin
@@ -240,7 +244,7 @@ jupyterhub:
     shared-storage-enabled: false
     shared-storage-groups: []       # allowlist; empty = all groups from token
     shared-storage-mount-prefix: "/shared"
-    # Role-gated shared-mount RBAC (Nebari issue #2304) configuration
+    # Role-gated shared-mount RBAC configuration
     # is delivered via the hub Deployment's env vars (KC_REALM_API_URL
     # + KC_SHARED_MOUNT_ROLE), NOT via this `custom` block. Reasons:
     #   * `custom.*` is rendered into the z2jh Secret's embedded

--- a/values.yaml
+++ b/values.yaml
@@ -166,6 +166,49 @@ nebi:
   # Port the Nebi server listens on (used in hub -> nebi NetworkPolicy egress rule).
   port: 8460
 
+# Helm Job that one-shots Keycloak realm config for role-gated shared
+# mounts (Nebari issue #2304). Runs as a post-install / post-upgrade
+# hook. Idempotent; skips cleanly if ``kcAdminCredentialSecret`` is
+# unset, so the chart can install on clusters that haven't yet
+# surfaced an admin credential.
+#
+# The Job:
+#   1. Adds the ``oidc-group-membership-mapper`` to the ``groups``
+#      client scope (the missing-mapper bug that surfaces as an empty
+#      groups claim on tokens).
+#   2. Creates the ``allow-group-directory-creation-role`` client
+#      role on the hub OIDC client with attributes
+#      ``component=shared-directory`` and
+#      ``scopes=write:shared-mount`` (same role classic nebari
+#      provisions).
+#   3. Grants the hub client ``serviceAccountsEnabled=true`` and
+#      binds ``realm-management.{view-clients,view-groups,view-realm}``
+#      to its service account.
+#   4. Assigns the shared-mount role to the KC groups in
+#      ``sharedMountGroups``.
+#
+# Runtime config the hub itself reads (admin API URL + role name)
+# goes under ``jupyterhub.custom.rbac-*`` — see below.
+rbac:
+  bootstrap:
+    enabled: false
+    # Name of a K8s Secret holding the KC realm-admin password in key
+    # ``password``. Job authenticates as ``admin`` in the ``master``
+    # realm via kcadm.sh and applies config to ``realmName``.
+    kcAdminCredentialSecret: ""
+    # Realm to bootstrap.
+    realmName: "nebari"
+    # ClientId of the hub OAuth client in Keycloak (created by the
+    # nebari-operator NebariApp). The role + SA roles attach here.
+    hubClientId: ""
+    # KC group paths to assign the shared-mount role to. Each path
+    # must already exist in KC. e.g.
+    #   - /admin
+    #   - /developer
+    sharedMountGroups: []
+    # Image used to run kcadm.sh (matches the realm's Keycloak version).
+    image: "quay.io/keycloak/keycloak:24.0.5"
+
 # JupyterHub configuration
 # All values under this key are passed to the jupyterhub subchart
 jupyterhub:
@@ -190,6 +233,20 @@ jupyterhub:
     shared-storage-enabled: false
     shared-storage-groups: []       # allowlist; empty = all groups from token
     shared-storage-mount-prefix: "/shared"
+    # Role-gated shared-mount RBAC (Nebari issue #2304).
+    # When ``rbac-realm-api-url`` is set, the hub calls KC's Admin API
+    # on every login + refresh to find which of the user's KC groups
+    # hold ``rbac-shared-mount-role-name`` on the hub OIDC client.
+    # The spawner then mounts only ``/shared/<group>`` for that
+    # filtered subset. Empty URL = RBAC disabled = spawner falls back
+    # to mounting every group the user is in (legacy behaviour).
+    #
+    # KC requirements: the hub OAuth client needs
+    # ``serviceAccountsEnabled=true`` and realm-management roles
+    # (view-clients, view-groups, view-realm) bound to its SA. The
+    # chart's ``rbac.bootstrap`` Helm Job provisions this.
+    rbac-realm-api-url: ""
+    rbac-shared-mount-role-name: "allow-group-directory-creation-role"
     # jhub-apps (JAppsConfig) overrides.
     # Any key here is set as an attribute on c.JAppsConfig before install_jhub_apps().
     # See https://jhub-apps.nebari.dev/docs/configuration for available options.


### PR DESCRIPTION
Closes #64.

Role-gated shared-mount RBAC for JupyterHub. Membership in a Keycloak group is necessary but no longer sufficient for a `/shared/<group>` mount; the group must also hold the `allow-group-directory-creation-role` on the hub OIDC client.

**Hub side:**

- `KCRealmAdmin` — deep module, one public method, hides the KC Admin API plumbing (client_credentials grant, role+attrs fetch, role→groups fetch, intersection with user's groups).
- `KeyCloakOAuthenticator.update_auth_model` writes `auth_state["groups_with_permission_to_mount"]` on login.
- `refresh_user` re-evaluates on each refresh — KC role changes take effect mid-session.
- Spawner reads the filtered set; falls back to `auth_state["groups"]` when absent (RBAC disabled = legacy).
- KC Admin API failure ≠ login failure — empty filter, log a warning.
- Config via hub Deployment env (`KC_REALM_API_URL`, `KC_SHARED_MOUNT_ROLE`) so it works on clusters that pin the z2jh Secret via Argo `ignoreDifferences`.

**Realm side:**

- Helm post-install/post-upgrade Job runs `kcadm.sh` idempotently: group-membership mapper on the `groups` scope, the role with the right attributes on the hub client, `serviceAccountsEnabled` + realm-management roles bound to the hub SA, role assigned to `rbac.bootstrap.sharedMountGroups`.
- Disabled by default; opt-in via `rbac.bootstrap.enabled=true` + a Secret ref. Skips cleanly otherwise.

Also bundles the symlink-trap fix for `~/shared` so group membership changes (gain / lose / swap) are idempotent across spawns.

**Tests:** 37 unit tests, real-behaviour through public interfaces, KC Admin API mocked at the HTTP boundary.

**Verified end-to-end** on a production NIC cluster: a user in the role-granted group sees `~/shared -> /shared` and `/shared/<group>` mounted; a user in no role-granted groups sees no shared mount; login still works when the KC Admin API is unreachable.

Follow-up tracked in #63: e2e coverage for the RBAC path + matrix-split the Test Deployment workflow for faster CI.