### PR TITLE
ci: matrix-split e2e (one cluster per test file)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,21 +66,16 @@ jobs:
           docker pull "${{ steps.img.outputs.ref }}"
           docker save "${{ steps.img.outputs.ref }}" -o "${{ steps.img.outputs.tar }}"
 
-  # Matrix-split e2e: one job per test file. Each leg gets its own kind
-  # cluster, helm install, and parallel runner. Wall time = max(leg)
-  # instead of sum, so adding a new test file does not extend the
-  # critical path.
+  # Single e2e job with pytest-xdist parallelism. Per-test matrix would
+  # cost 10× kind+helm bootstrap (~45 s each); xdist pays the bootstrap
+  # once and runs N tests concurrently against the same hub. ubuntu-latest
+  # runners are 4 vCPU / 16 GB so -n 4 fits within z2jh's default
+  # singleuser resource asks (0.5 CPU + 1 GB per pod) without throttling.
   e2e:
-    name: e2e (${{ matrix.test_file }})
+    name: e2e
     runs-on: ubuntu-latest
     needs: prep
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        test_file:
-          - test_smoke.py
-          - test_shared_storage.py
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
@@ -103,32 +98,25 @@ jobs:
           key: singleuser-${{ needs.prep.outputs.ref }}
           fail-on-cache-miss: true
 
-      # Per-leg cluster name so concurrent matrix runs don't trample
-      # each other on the runner-shared docker daemon (unlikely on
-      # ubuntu-latest but cheap insurance + matches what conftest.py
-      # already reads from KIND_CLUSTER).
-      - name: Derive cluster name
-        id: cluster
-        run: |
-          STEM="${{ matrix.test_file }}"
-          STEM="${STEM%.py}"
-          STEM="${STEM#test_}"
-          # kind cluster names limited to 38 chars + must be DNS-1123.
-          NAME=$(echo "nbe2e-${STEM}" | tr '_' '-' | cut -c1-38)
-          echo "name=$NAME" >> "$GITHUB_OUTPUT"
-
       - name: Create kind cluster
-        run: kind create cluster --name "${{ steps.cluster.outputs.name }}" --wait 60s
+        run: kind create cluster --name nbtest-e2e --wait 60s
 
       - name: Side-load singleuser image into kind node
-        run: kind load image-archive "${{ needs.prep.outputs.tar }}" --name "${{ steps.cluster.outputs.name }}"
+        run: kind load image-archive "${{ needs.prep.outputs.tar }}" --name nbtest-e2e
 
-      - name: Run e2e tests
+      - name: Run e2e tests (xdist -n 4)
         env:
-          KIND_CLUSTER: ${{ steps.cluster.outputs.name }}
+          KIND_CLUSTER: nbtest-e2e
           KIND_KEEP: "1"
           PYTHONUNBUFFERED: "1"
-        run: uvx pytest "tests/e2e/${{ matrix.test_file }}" -v --color=yes
+        # pytest-xdist runs tests in parallel worker processes; each
+        # worker spawns its own user via the spawn_user fixture so the
+        # hub handles N concurrent pod creations. --dist=loadfile keeps
+        # tests from the same file on the same worker — preserves any
+        # per-file fixture state if it's added later. -n 4 matches the
+        # runner's vCPU count and leaves RAM headroom for the kind
+        # control plane + hub + proxy + 4 user pods.
+        run: uvx --with pytest-xdist pytest tests/e2e -v --color=yes -n 4 --dist=loadfile --durations=10
 
       - name: Hub logs on failure
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,29 +77,32 @@ jobs:
       - name: Collect e2e test node IDs into a JSON array
         id: collect
         run: |
-          # `pytest --collect-only -q` prints one node id per line plus
-          # a "<n> tests collected" trailer. Strip the trailer (line
-          # containing "collected") + blank lines, then jq -R -s -c
-          # turns the lines into a single-line JSON array suitable for
-          # `fromJSON` in the matrix below.
-          # tests/e2e/pytest.ini sets rootdir to tests/e2e, so collected
-          # IDs come out as `test_x.py::test_y` (no `tests/e2e/`
-          # prefix). Re-add the prefix so each matrix leg can pass the
-          # node id back to pytest from the repo root.
+          # Emit `[{"id":"<short>","path":"<full pytest node id>"}, …]`.
+          # `id` becomes the matrix label so the GitHub UI groups the
+          # legs as `e2e / <short>` instead of the full file path
+          # noise. `path` is what pytest needs to run the test.
+          # tests/e2e/pytest.ini sets rootdir to tests/e2e, so the
+          # collected IDs come without the prefix; add it back.
           uvx pytest tests/e2e --collect-only -q 2>/dev/null \
             | grep -E '^test_.*::' \
-            | sed 's|^|tests/e2e/|' \
-            | jq -R . | jq -s -c . > /tmp/tests.json
+            | while IFS= read -r node; do
+                # node = test_FILE.py::test_FN[param]
+                # short = FN[param] (or FN if not parametrized)
+                short=$(echo "$node" | sed -E 's|^test_[^.]+\.py::test_||')
+                jq -n --arg id "$short" --arg path "tests/e2e/$node" \
+                  '{id: $id, path: $path}'
+              done \
+            | jq -s -c . > /tmp/tests.json
           echo "tests=$(cat /tmp/tests.json)" >> "$GITHUB_OUTPUT"
           echo "Collected:"
-          cat /tmp/tests.json | jq -r '.[]'
+          cat /tmp/tests.json | jq -r '.[] | "\(.id) \t\(.path)"'
 
   # Matrix-per-test e2e: each leg gets its own kind cluster, helm
   # install, and runs ONE pytest node id. Wall time = max(leg) instead
   # of sum(tests). Adding a test is free — prep job's collection adds
   # a matrix leg automatically.
   e2e:
-    name: e2e
+    name: e2e / ${{ matrix.test.id }}
     runs-on: ubuntu-latest
     needs: prep
     timeout-minutes: 10
@@ -136,8 +139,7 @@ jobs:
       - name: Derive cluster name
         id: cluster
         run: |
-          T='${{ matrix.test }}'
-          SAFE=$(echo "$T" | sha1sum | cut -c1-12)
+          SAFE=$(echo '${{ matrix.test.path }}' | sha1sum | cut -c1-12)
           echo "name=nbe2e-${SAFE}" >> "$GITHUB_OUTPUT"
 
       - name: Create kind cluster
@@ -151,7 +153,7 @@ jobs:
           KIND_CLUSTER: ${{ steps.cluster.outputs.name }}
           KIND_KEEP: "1"
           PYTHONUNBUFFERED: "1"
-        run: uvx pytest "${{ matrix.test }}" -v --color=yes
+        run: uvx pytest "${{ matrix.test.path }}" -v --color=yes
 
       - name: Hub logs on failure
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,30 +31,21 @@ jobs:
       - name: pytest tests/unit
         run: .venv-unit/bin/python -m pytest tests/unit -v --color=yes
 
-  e2e:
+  # Pre-bake the singleuser image tar ONCE in its own job and share via
+  # actions/cache. All matrix legs pull from the cache instead of each
+  # paying the ~73s docker-pull cost. The cache key is the image ref so
+  # a values.yaml bump invalidates automatically.
+  prep:
+    name: prep singleuser image
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-
+    timeout-minutes: 5
+    outputs:
+      ref: ${{ steps.img.outputs.ref }}
+      tar: ${{ steps.img.outputs.tar }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
-      - name: Install kind
-        run: |
-          curl -fsSLo /tmp/kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
-          sudo install -m 0755 /tmp/kind /usr/local/bin/kind
-
-      - name: Install Helm
-        run: curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-      # Singleuser image is multi-GB and is the dominant cold-start cost
-      # (~73s pulled in-cluster during the first test). Cache the tar across
-      # CI runs and side-load it into kind so kubelet never goes to the
-      # registry. Cache key is the image ref so a `values.yaml` bump
-      # invalidates automatically.
       - name: Resolve singleuser image ref
         id: img
         run: |
@@ -75,21 +66,69 @@ jobs:
           docker pull "${{ steps.img.outputs.ref }}"
           docker save "${{ steps.img.outputs.ref }}" -o "${{ steps.img.outputs.tar }}"
 
-      # Pre-create the cluster here (instead of letting the pytest fixture
-      # do it) so we can side-load the cached image before any pod is
-      # scheduled. The fixture's ensure_cluster() reuses an existing one.
+  # Matrix-split e2e: one job per test file. Each leg gets its own kind
+  # cluster, helm install, and parallel runner. Wall time = max(leg)
+  # instead of sum, so adding a new test file does not extend the
+  # critical path.
+  e2e:
+    name: e2e (${{ matrix.test_file }})
+    runs-on: ubuntu-latest
+    needs: prep
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        test_file:
+          - test_smoke.py
+          - test_shared_storage.py
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Install kind
+        run: |
+          curl -fsSLo /tmp/kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+          sudo install -m 0755 /tmp/kind /usr/local/bin/kind
+
+      - name: Install Helm
+        run: curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Restore singleuser image from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ${{ needs.prep.outputs.tar }}
+          key: singleuser-${{ needs.prep.outputs.ref }}
+          fail-on-cache-miss: true
+
+      # Per-leg cluster name so concurrent matrix runs don't trample
+      # each other on the runner-shared docker daemon (unlikely on
+      # ubuntu-latest but cheap insurance + matches what conftest.py
+      # already reads from KIND_CLUSTER).
+      - name: Derive cluster name
+        id: cluster
+        run: |
+          STEM="${{ matrix.test_file }}"
+          STEM="${STEM%.py}"
+          STEM="${STEM#test_}"
+          # kind cluster names limited to 38 chars + must be DNS-1123.
+          NAME=$(echo "nbe2e-${STEM}" | tr '_' '-' | cut -c1-38)
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
       - name: Create kind cluster
-        run: kind create cluster --name nbtest-e2e --wait 60s
+        run: kind create cluster --name "${{ steps.cluster.outputs.name }}" --wait 60s
 
       - name: Side-load singleuser image into kind node
-        run: kind load image-archive "${{ steps.img.outputs.tar }}" --name nbtest-e2e
+        run: kind load image-archive "${{ needs.prep.outputs.tar }}" --name "${{ steps.cluster.outputs.name }}"
 
       - name: Run e2e tests
         env:
-          KIND_CLUSTER: "nbtest-e2e"  # reuse the cluster created above
-          KIND_KEEP: "1"  # runner is ephemeral, skip teardown
-          PYTHONUNBUFFERED: "1"  # stream logs live (no block buffering on non-TTY)
-        run: uvx pytest tests/e2e -v --color=yes
+          KIND_CLUSTER: ${{ steps.cluster.outputs.name }}
+          KIND_KEEP: "1"
+          PYTHONUNBUFFERED: "1"
+        run: uvx pytest "tests/e2e/${{ matrix.test_file }}" -v --color=yes
 
       - name: Hub logs on failure
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,20 +31,28 @@ jobs:
       - name: pytest tests/unit
         run: .venv-unit/bin/python -m pytest tests/unit -v --color=yes
 
-  # Pre-bake the singleuser image tar ONCE in its own job and share via
-  # actions/cache. All matrix legs pull from the cache instead of each
-  # paying the ~73s docker-pull cost. The cache key is the image ref so
-  # a values.yaml bump invalidates automatically.
+  # Two roles for prep:
+  #   1. Cache the multi-GB singleuser image tar so every matrix leg
+  #      restores it from cache instead of paying the docker-pull cost.
+  #      Key by the chart-rendered image ref so values.yaml bumps
+  #      invalidate automatically.
+  #   2. Collect the list of pytest node IDs from tests/e2e/ and emit
+  #      it as a JSON array the matrix consumes. Adding/removing tests
+  #      flows through the matrix automatically with no workflow edits.
   prep:
-    name: prep singleuser image
+    name: prep (image + test matrix)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       ref: ${{ steps.img.outputs.ref }}
       tar: ${{ steps.img.outputs.tar }}
+      tests: ${{ steps.collect.outputs.tests }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Resolve singleuser image ref
         id: img
@@ -66,16 +74,40 @@ jobs:
           docker pull "${{ steps.img.outputs.ref }}"
           docker save "${{ steps.img.outputs.ref }}" -o "${{ steps.img.outputs.tar }}"
 
-  # Single e2e job with pytest-xdist parallelism. Per-test matrix would
-  # cost 10× kind+helm bootstrap (~45 s each); xdist pays the bootstrap
-  # once and runs N tests concurrently against the same hub. ubuntu-latest
-  # runners are 4 vCPU / 16 GB so -n 4 fits within z2jh's default
-  # singleuser resource asks (0.5 CPU + 1 GB per pod) without throttling.
+      - name: Collect e2e test node IDs into a JSON array
+        id: collect
+        run: |
+          # `pytest --collect-only -q` prints one node id per line plus
+          # a "<n> tests collected" trailer. Strip the trailer (line
+          # containing "collected") + blank lines, then jq -R -s -c
+          # turns the lines into a single-line JSON array suitable for
+          # `fromJSON` in the matrix below.
+          # tests/e2e/pytest.ini sets rootdir to tests/e2e, so collected
+          # IDs come out as `test_x.py::test_y` (no `tests/e2e/`
+          # prefix). Re-add the prefix so each matrix leg can pass the
+          # node id back to pytest from the repo root.
+          uvx pytest tests/e2e --collect-only -q 2>/dev/null \
+            | grep -E '^test_.*::' \
+            | sed 's|^|tests/e2e/|' \
+            | jq -R . | jq -s -c . > /tmp/tests.json
+          echo "tests=$(cat /tmp/tests.json)" >> "$GITHUB_OUTPUT"
+          echo "Collected:"
+          cat /tmp/tests.json | jq -r '.[]'
+
+  # Matrix-per-test e2e: each leg gets its own kind cluster, helm
+  # install, and runs ONE pytest node id. Wall time = max(leg) instead
+  # of sum(tests). Adding a test is free — prep job's collection adds
+  # a matrix leg automatically.
   e2e:
     name: e2e
     runs-on: ubuntu-latest
     needs: prep
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        test: ${{ fromJSON(needs.prep.outputs.tests) }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
@@ -98,45 +130,28 @@ jobs:
           key: singleuser-${{ needs.prep.outputs.ref }}
           fail-on-cache-miss: true
 
+      # Sanitise the pytest node id into a kind-cluster name: kind
+      # names are DNS-1123 (lowercase alnum + dashes) and max 38 chars.
+      # SHA1-truncate so duplicates can't collide.
+      - name: Derive cluster name
+        id: cluster
+        run: |
+          T='${{ matrix.test }}'
+          SAFE=$(echo "$T" | sha1sum | cut -c1-12)
+          echo "name=nbe2e-${SAFE}" >> "$GITHUB_OUTPUT"
+
       - name: Create kind cluster
-        run: kind create cluster --name nbtest-e2e --wait 60s
+        run: kind create cluster --name "${{ steps.cluster.outputs.name }}" --wait 60s
 
       - name: Side-load singleuser image into kind node
-        run: kind load image-archive "${{ needs.prep.outputs.tar }}" --name nbtest-e2e
+        run: kind load image-archive "${{ needs.prep.outputs.tar }}" --name "${{ steps.cluster.outputs.name }}"
 
-      # Setup runs ONCE here (outside pytest) so xdist workers don't
-      # race on helm install against the same release. SKIP_CLUSTER_SETUP
-      # tells the conftest cluster fixture to assume the cluster is up.
-      - name: Install chart + wait for hub
-        run: |
-          helm dependency update
-          helm upgrade --install ds . --namespace default \
-            --set nebariapp.enabled=false \
-            --values tests/e2e/fixtures/test-values.yaml
-          # Match conftest's kind /etc/hosts NFS workaround. The release
-          # name "ds" matches RELEASE in conftest.
-          NFS_IP=$(kubectl get svc ds-nebari-data-science-pack-nfs -o jsonpath='{.spec.clusterIP}' || true)
-          if [ -n "$NFS_IP" ]; then
-            docker exec nbtest-e2e-control-plane sh -c \
-              "grep -q ds-nebari-data-science-pack-nfs /etc/hosts || \
-               echo '$NFS_IP ds-nebari-data-science-pack-nfs.default.svc.cluster.local' >> /etc/hosts"
-          fi
-          kubectl wait --for=condition=Ready pod -l component=hub --timeout=300s
-          kubectl wait --for=condition=Ready pod -l component=proxy --timeout=180s
-
-      - name: Run e2e tests (xdist -n 4)
+      - name: Run single test
         env:
-          KIND_CLUSTER: nbtest-e2e
+          KIND_CLUSTER: ${{ steps.cluster.outputs.name }}
           KIND_KEEP: "1"
-          SKIP_CLUSTER_SETUP: "1"
           PYTHONUNBUFFERED: "1"
-        # pytest-xdist runs tests in parallel worker processes; each
-        # worker spawns its own user via the spawn_user fixture so the
-        # hub handles N concurrent pod creations. --dist=loadfile keeps
-        # tests from the same file on the same worker. -n 4 matches the
-        # runner's vCPU count and leaves RAM headroom for the kind
-        # control plane + hub + proxy + 4 user pods.
-        run: uvx --with pytest-xdist pytest tests/e2e -v --color=yes -n 4 --dist=loadfile --durations=10
+        run: uvx pytest "${{ matrix.test }}" -v --color=yes
 
       - name: Hub logs on failure
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,16 +104,36 @@ jobs:
       - name: Side-load singleuser image into kind node
         run: kind load image-archive "${{ needs.prep.outputs.tar }}" --name nbtest-e2e
 
+      # Setup runs ONCE here (outside pytest) so xdist workers don't
+      # race on helm install against the same release. SKIP_CLUSTER_SETUP
+      # tells the conftest cluster fixture to assume the cluster is up.
+      - name: Install chart + wait for hub
+        run: |
+          helm dependency update
+          helm upgrade --install ds . --namespace default \
+            --set nebariapp.enabled=false \
+            --values tests/e2e/fixtures/test-values.yaml
+          # Match conftest's kind /etc/hosts NFS workaround. The release
+          # name "ds" matches RELEASE in conftest.
+          NFS_IP=$(kubectl get svc ds-nebari-data-science-pack-nfs -o jsonpath='{.spec.clusterIP}' || true)
+          if [ -n "$NFS_IP" ]; then
+            docker exec nbtest-e2e-control-plane sh -c \
+              "grep -q ds-nebari-data-science-pack-nfs /etc/hosts || \
+               echo '$NFS_IP ds-nebari-data-science-pack-nfs.default.svc.cluster.local' >> /etc/hosts"
+          fi
+          kubectl wait --for=condition=Ready pod -l component=hub --timeout=300s
+          kubectl wait --for=condition=Ready pod -l component=proxy --timeout=180s
+
       - name: Run e2e tests (xdist -n 4)
         env:
           KIND_CLUSTER: nbtest-e2e
           KIND_KEEP: "1"
+          SKIP_CLUSTER_SETUP: "1"
           PYTHONUNBUFFERED: "1"
         # pytest-xdist runs tests in parallel worker processes; each
         # worker spawns its own user via the spawn_user fixture so the
         # hub handles N concurrent pod creations. --dist=loadfile keeps
-        # tests from the same file on the same worker — preserves any
-        # per-file fixture state if it's added later. -n 4 matches the
+        # tests from the same file on the same worker. -n 4 matches the
         # runner's vCPU count and leaves RAM headroom for the kind
         # control plane + hub + proxy + 4 user pods.
         run: uvx --with pytest-xdist pytest tests/e2e -v --color=yes -n 4 --dist=loadfile --durations=10

--- a/tests/e2e/_cluster.py
+++ b/tests/e2e/_cluster.py
@@ -93,12 +93,23 @@ def patch_nfs_hosts_entry(release, cluster_name):
 
     Production clusters don't need this — their kubelets have cluster DNS.
     """
-    rc, pv_name, _ = kctl_out(
-        "get", "pv", "-l", f"app.kubernetes.io/instance={release}",
-        "-o", "jsonpath={.items[?(@.spec.nfs)].metadata.name}",
-    )
+    # On a freshly-helm-installed cluster the PV controller can take
+    # 20-60s to bind the NFS PV. Poll up to ~90s; each kctl_out call
+    # has its own 10s default timeout (kubectl itself is allowed to
+    # stall while the API server is still warming up on cold kind).
+    pv_name = ""
+    deadline = time.time() + 90
+    while time.time() < deadline:
+        rc, pv_name, _ = kctl_out(
+            "get", "pv", "-l", f"app.kubernetes.io/instance={release}",
+            "-o", "jsonpath={.items[?(@.spec.nfs)].metadata.name}",
+            timeout=15,
+        )
+        if pv_name:
+            break
+        time.sleep(2)
     if not pv_name:
-        log.info("no NFS-backed PV found — skipping hosts entry")
+        log.info("no NFS-backed PV found after 90s — skipping hosts entry")
         return
 
     _, fqdn, _ = kctl_out("get", "pv", pv_name,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -78,6 +78,18 @@ def dump_diagnostics_on_failure(request):
 
 @pytest.fixture(scope="session")
 def cluster():
+    # SKIP_CLUSTER_SETUP=1 means the CI workflow (or a wrapper script)
+    # has already created the kind cluster, installed the chart, patched
+    # the NFS hosts entry, and waited for the hub. Required for
+    # pytest-xdist runs: every xdist worker has its own pytest session,
+    # so without this flag all N workers would race on `helm upgrade
+    # --install` against the same release and 3-of-4 would fail.
+    if os.environ.get("SKIP_CLUSTER_SETUP"):
+        log.info("SKIP_CLUSTER_SETUP=1; assuming kind + helm already up")
+        require_binaries("kind", "helm", "kubectl")
+        yield CLUSTER
+        return
+
     TOTAL = 6
     step(1, TOTAL, "verify required binaries on PATH")
     require_binaries("kind", "helm", "kubectl")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -78,18 +78,6 @@ def dump_diagnostics_on_failure(request):
 
 @pytest.fixture(scope="session")
 def cluster():
-    # SKIP_CLUSTER_SETUP=1 means the CI workflow (or a wrapper script)
-    # has already created the kind cluster, installed the chart, patched
-    # the NFS hosts entry, and waited for the hub. Required for
-    # pytest-xdist runs: every xdist worker has its own pytest session,
-    # so without this flag all N workers would race on `helm upgrade
-    # --install` against the same release and 3-of-4 would fail.
-    if os.environ.get("SKIP_CLUSTER_SETUP"):
-        log.info("SKIP_CLUSTER_SETUP=1; assuming kind + helm already up")
-        require_binaries("kind", "helm", "kubectl")
-        yield CLUSTER
-        return
-
     TOTAL = 6
     step(1, TOTAL, "verify required binaries on PATH")
     require_binaries("kind", "helm", "kubectl")


### PR DESCRIPTION
Refs #63.

Splits the monolithic `e2e` job into a matrix axis on test file. Each leg runs its own kind cluster against one file in parallel. Wall time becomes `max(leg)` instead of `sum(files)`.

Also extracts a `prep` job that pulls + caches the singleuser image tar once; matrix legs restore from cache (avoids paying the ~73s docker-pull cost N times).

`fail-fast: false` so a flaky file doesn't cancel the rest.

Adding a new e2e test file is now a one-line matrix entry — no workflow rewrite.