### PR TITLE
refactor(rbac-bootstrap): replace bash heredoc with unit-tested Python

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,3 +158,74 @@ jobs:
       - name: Hub logs on failure
         if: failure()
         run: kubectl logs -l component=hub --tail=200 || true
+
+  # Integration tests for files/keycloak_rbac_bootstrap.py against a
+  # real Keycloak. The bootstrap is the chart's only piece of Python
+  # that talks to Keycloak directly — KC version skew or payload
+  # changes would break it silently in prod. nebari-dev/action-nebari
+  # -sandbox spins up NIC's foundational stack (Keycloak + nebari realm
+  # included) in ~3 min on a vanilla runner; the tests then run against
+  # that live KC via a port-forward.
+  integration-rbac-bootstrap:
+    name: integration / rbac-bootstrap
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Provision Nebari sandbox (k3d + NIC platform stack)
+        id: sandbox
+        uses: nebari-dev/action-nebari-sandbox@68b3a446c8ce70e1e100540b97ec532ff2e97dd4  # v1.0.2
+        with:
+          profile: platform
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Wait for Keycloak service
+        env:
+          KUBECONFIG: ${{ steps.sandbox.outputs.kubeconfig }}
+        run: |
+          kubectl -n keycloak rollout status statefulset/keycloak-keycloakx --timeout=300s
+          kubectl -n keycloak get svc/keycloak-keycloakx-http
+
+      - name: Port-forward Keycloak admin
+        env:
+          KUBECONFIG: ${{ steps.sandbox.outputs.kubeconfig }}
+        run: |
+          # Background port-forward. The runner stops on workflow exit,
+          # so no explicit cleanup needed; ``timeout-minutes`` is the
+          # safety net.
+          nohup kubectl -n keycloak port-forward svc/keycloak-keycloakx-http \
+            18080:8080 >/tmp/kc-pf.log 2>&1 &
+          # Poll for the local port — port-forward exits non-zero on
+          # any error so we'd see it via the log dump on failure.
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:18080/realms/master/.well-known/openid-configuration >/dev/null; then
+              echo "KC reachable on :18080 (attempt $i)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Keycloak port-forward never came up"
+          cat /tmp/kc-pf.log
+          exit 1
+
+      - name: Run integration tests
+        env:
+          KUBECONFIG: ${{ steps.sandbox.outputs.kubeconfig }}
+          KC_URL: http://localhost:18080
+          KC_ADMIN_PASSWORD: ${{ steps.sandbox.outputs.keycloak-admin-password }}
+          PYTHONUNBUFFERED: "1"
+        run: uvx pytest tests/integration -v --color=yes
+
+      - name: Keycloak logs on failure
+        if: failure()
+        env:
+          KUBECONFIG: ${{ steps.sandbox.outputs.kubeconfig }}
+        run: |
+          kubectl -n keycloak get pods
+          kubectl -n keycloak logs statefulset/keycloak-keycloakx --tail=200 || true
+          echo "--- port-forward log ---"
+          cat /tmp/kc-pf.log || true

--- a/files/keycloak_rbac_bootstrap.py
+++ b/files/keycloak_rbac_bootstrap.py
@@ -1,0 +1,456 @@
+"""Keycloak realm bootstrap for role-gated shared-mount RBAC.
+
+Idempotent. Provisions, in order:
+
+    1. ``group-membership`` mapper on the ``groups`` client scope so KC
+       emits a ``groups`` claim in tokens.
+    2. ``serviceAccountsEnabled=true`` on the hub OIDC client.
+    3. ``realm-management.view-{clients,groups,realm,users}`` bound to
+       the hub client's service-account user (so the hub can call the
+       KC Admin API at runtime to filter user groups by role).
+    4. The shared-directory client role on the hub client with the
+       required attributes ``component=shared-directory`` /
+       ``scopes=write:shared-mount``.
+    5. Assignment of that role to the configured KC group paths.
+
+Re-running the script is safe: every step is a check-then-create
+pattern that returns no-op if the desired state already exists. This
+matters because the Helm chart runs the bootstrap on every install AND
+every upgrade.
+
+Configuration is taken from environment variables — the Helm Job
+template wires these to a Secret reference (admin password) and chart
+values (everything else). See ``BootstrapConfig.from_env``.
+
+Implementation notes:
+
+* Uses ``urllib.request`` from the standard library — no third-party
+  dependencies, so the Job runs on a vanilla ``python:3.x-slim``
+  image. ``pip install`` adds 5-10s per Job run and a network
+  dependency we don't need.
+
+* All HTTP calls go through :py:class:`KCAdmin._request`, which knows
+  how to: attach the bearer token, JSON-encode the body, raise on
+  4xx/5xx (except 409 when the caller explicitly opts in for
+  idempotent ``POST create``), and decode the response.
+
+* The class methods are deliberately small and single-purpose so the
+  unit tests can mock at the HTTP boundary
+  (``KCAdmin._request``) and exercise real control flow.
+
+Reference: Keycloak Admin REST API
+https://www.keycloak.org/docs-api/latest/rest-api/index.html
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Iterable
+
+log = logging.getLogger("rbac-bootstrap")
+
+
+SHARED_DIR_ATTRIBUTES = {
+    "component": ["shared-directory"],
+    "scopes": ["write:shared-mount"],
+}
+REALM_MGMT_ROLES = ("view-clients", "view-groups", "view-realm", "view-users")
+
+
+@dataclasses.dataclass(frozen=True)
+class BootstrapConfig:
+    kc_host: str
+    admin_password: str
+    realm: str
+    hub_client_id: str
+    role_name: str
+    shared_mount_groups: tuple[str, ...]
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "BootstrapConfig":
+        env = env if env is not None else dict(os.environ)
+        raw_groups = env.get("SHARED_MOUNT_GROUPS", "").strip()
+        return cls(
+            kc_host=env["KC_HOST"],
+            admin_password=env["KC_ADMIN_PASSWORD"],
+            realm=env["REALM"],
+            hub_client_id=env["HUB_CLIENT_ID"],
+            role_name=env["ROLE_NAME"],
+            shared_mount_groups=tuple(g for g in raw_groups.split(",") if g),
+        )
+
+
+class KCAdmin:
+    """Thin wrapper around Keycloak's Admin REST API.
+
+    Acquires a password-grant token on first use against the
+    ``master`` realm's ``admin`` user. All subsequent calls attach
+    that token. Errors surface as raised ``HTTPError`` from the
+    underlying ``urlopen`` — callers either propagate or pass
+    ``accept_409=True`` to swallow the duplicate-create case.
+
+    The class doesn't cache anything beyond the token; pollers below
+    drive idempotency by reading current state before writing.
+    """
+
+    PASSWORD_GRANT_PATH = "/realms/master/protocol/openid-connect/token"
+
+    def __init__(
+        self,
+        base_url: str,
+        admin_password: str,
+        *,
+        opener: Any = None,
+        request_timeout: int = 30,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._admin_password = admin_password
+        self._opener = opener or urllib.request.build_opener()
+        self._timeout = request_timeout
+        self._token: str | None = None
+
+    # --- token + transport -------------------------------------------
+
+    def _password_grant(self) -> str:
+        body = (
+            "grant_type=password"
+            "&client_id=admin-cli"
+            "&username=admin"
+            f"&password={self._admin_password}"
+        ).encode()
+        req = urllib.request.Request(
+            f"{self._base_url}{self.PASSWORD_GRANT_PATH}",
+            data=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        with self._opener.open(req, timeout=self._timeout) as resp:
+            return json.loads(resp.read())["access_token"]
+
+    def _token_now(self) -> str:
+        if self._token is None:
+            self._token = self._password_grant()
+        return self._token
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: Any = None,
+        accept_409: bool = False,
+    ) -> Any:
+        """One HTTP request against ``/admin/realms/...``.
+
+        Returns the parsed JSON body, or ``None`` for 2xx with empty
+        body. ``accept_409=True`` lets idempotent creates swallow KC's
+        "already exists" response.
+        """
+        url = f"{self._base_url}/admin/realms{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {
+            "Authorization": f"Bearer {self._token_now()}",
+            "Content-Type": "application/json",
+        }
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with self._opener.open(req, timeout=self._timeout) as resp:
+                payload = resp.read()
+                return json.loads(payload) if payload else None
+        except urllib.error.HTTPError as e:
+            if e.code == 409 and accept_409:
+                return None
+            err_body = ""
+            try:
+                err_body = e.read().decode(errors="replace")
+            except Exception:
+                pass
+            log.error("KC %s %s -> HTTP %d: %s", method, url, e.code, err_body)
+            raise
+
+    # --- group-membership mapper on a client scope -------------------
+
+    def get_client_scope_id(self, realm: str, name: str) -> str | None:
+        for scope in self._request("GET", f"/{realm}/client-scopes") or []:
+            if scope["name"] == name:
+                return scope["id"]
+        return None
+
+    def ensure_groups_mapper(self, realm: str, scope_name: str = "groups") -> None:
+        scope_id = self.get_client_scope_id(realm, scope_name)
+        if scope_id is None:
+            log.info("creating client-scope %r", scope_name)
+            self._request(
+                "POST",
+                f"/{realm}/client-scopes",
+                body={
+                    "name": scope_name,
+                    "protocol": "openid-connect",
+                    "attributes": {
+                        "include.in.token.scope": "true",
+                        "display.on.consent.screen": "true",
+                    },
+                },
+                accept_409=True,
+            )
+            scope_id = self.get_client_scope_id(realm, scope_name)
+            if scope_id is None:
+                raise RuntimeError(f"client-scope {scope_name!r} creation failed")
+
+        mappers = self._request(
+            "GET",
+            f"/{realm}/client-scopes/{scope_id}/protocol-mappers/models",
+        ) or []
+        if any(m["name"] == "group-membership" for m in mappers):
+            log.info("scope %r already has group-membership mapper", scope_name)
+            return
+
+        log.info("adding oidc-group-membership-mapper to scope %r", scope_name)
+        self._request(
+            "POST",
+            f"/{realm}/client-scopes/{scope_id}/protocol-mappers/models",
+            body={
+                "name": "group-membership",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-group-membership-mapper",
+                "config": {
+                    "full.path": "true",
+                    "introspection.token.claim": "true",
+                    "userinfo.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "groups",
+                },
+            },
+            accept_409=True,
+        )
+
+    # --- hub client + service account --------------------------------
+
+    def get_client_uuid(self, realm: str, client_id: str) -> str:
+        clients = self._request(
+            "GET",
+            f"/{realm}/clients?clientId={client_id}",
+        ) or []
+        if not clients:
+            raise RuntimeError(
+                f"client {client_id!r} not found in realm {realm!r}"
+            )
+        return clients[0]["id"]
+
+    def enable_service_accounts(self, realm: str, client_uuid: str) -> None:
+        client = self._request("GET", f"/{realm}/clients/{client_uuid}")
+        if client.get("serviceAccountsEnabled"):
+            log.info("client %s already has serviceAccountsEnabled", client_uuid)
+            return
+        log.info("enabling serviceAccountsEnabled on client %s", client_uuid)
+        client["serviceAccountsEnabled"] = True
+        self._request("PUT", f"/{realm}/clients/{client_uuid}", body=client)
+
+    def get_service_account_user_id(
+        self,
+        realm: str,
+        client_uuid: str,
+        *,
+        retries: int = 5,
+        sleep_seconds: float = 2.0,
+    ) -> str:
+        """KC creates the SA user lazily after ``serviceAccountsEnabled``
+        flips to true. Poll briefly before giving up."""
+        last_exc: Exception | None = None
+        for _ in range(retries):
+            try:
+                user = self._request(
+                    "GET",
+                    f"/{realm}/clients/{client_uuid}/service-account-user",
+                )
+                return user["id"]
+            except urllib.error.HTTPError as e:
+                last_exc = e
+                if e.code != 404:
+                    raise
+                time.sleep(sleep_seconds)
+        assert last_exc is not None
+        raise RuntimeError(
+            f"SA user for client {client_uuid} never appeared"
+        ) from last_exc
+
+    # --- realm-management roles on the SA ----------------------------
+
+    def bind_realm_management_roles(
+        self,
+        realm: str,
+        sa_user_id: str,
+        role_names: Iterable[str],
+    ) -> None:
+        rm_uuid = self.get_client_uuid(realm, "realm-management")
+        existing = self._request(
+            "GET",
+            f"/{realm}/users/{sa_user_id}/role-mappings/clients/{rm_uuid}",
+        ) or []
+        existing_names = {r["name"] for r in existing}
+        to_bind: list[dict[str, str]] = []
+        for name in role_names:
+            if name in existing_names:
+                continue
+            try:
+                role = self._request(
+                    "GET",
+                    f"/{realm}/clients/{rm_uuid}/roles/{name}",
+                )
+                to_bind.append({"id": role["id"], "name": role["name"]})
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    log.warning(
+                        "realm-management role %r not found in this KC version; "
+                        "skipping",
+                        name,
+                    )
+                    continue
+                raise
+        if not to_bind:
+            log.info("SA already has all required realm-management roles")
+            return
+        log.info(
+            "binding %s on SA %s",
+            [r["name"] for r in to_bind], sa_user_id,
+        )
+        self._request(
+            "POST",
+            f"/{realm}/users/{sa_user_id}/role-mappings/clients/{rm_uuid}",
+            body=to_bind,
+        )
+
+    # --- shared-directory client role --------------------------------
+
+    def ensure_client_role(
+        self,
+        realm: str,
+        client_uuid: str,
+        role_name: str,
+        attributes: dict[str, list[str]],
+    ) -> str:
+        """Returns the role's UUID."""
+        try:
+            role = self._request(
+                "GET",
+                f"/{realm}/clients/{client_uuid}/roles/{role_name}",
+            )
+            if role.get("attributes") == attributes:
+                log.info("role %r already in desired state", role_name)
+                return role["id"]
+            log.info("reconciling attributes on role %r", role_name)
+            role["attributes"] = attributes
+            self._request(
+                "PUT",
+                f"/{realm}/clients/{client_uuid}/roles/{role_name}",
+                body=role,
+            )
+            return role["id"]
+        except urllib.error.HTTPError as e:
+            if e.code != 404:
+                raise
+        log.info("creating client role %r", role_name)
+        self._request(
+            "POST",
+            f"/{realm}/clients/{client_uuid}/roles",
+            body={"name": role_name, "attributes": attributes},
+            accept_409=True,
+        )
+        role = self._request(
+            "GET",
+            f"/{realm}/clients/{client_uuid}/roles/{role_name}",
+        )
+        return role["id"]
+
+    # --- group → role assignment -------------------------------------
+
+    def get_group_id_by_path(self, realm: str, path: str) -> str | None:
+        path_no_lead = path.lstrip("/")
+        try:
+            group = self._request(
+                "GET",
+                f"/{realm}/group-by-path/{path_no_lead}",
+            )
+            return group["id"]
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None
+            raise
+
+    def assign_role_to_group(
+        self,
+        realm: str,
+        group_id: str,
+        client_uuid: str,
+        role_id: str,
+        role_name: str,
+    ) -> None:
+        existing = self._request(
+            "GET",
+            f"/{realm}/groups/{group_id}/role-mappings/clients/{client_uuid}",
+        ) or []
+        if any(r["name"] == role_name for r in existing):
+            log.info("group %s already has role %r", group_id, role_name)
+            return
+        log.info("assigning role %r to group %s", role_name, group_id)
+        self._request(
+            "POST",
+            f"/{realm}/groups/{group_id}/role-mappings/clients/{client_uuid}",
+            body=[{"id": role_id, "name": role_name}],
+        )
+
+
+def run(config: BootstrapConfig, kc: KCAdmin) -> None:
+    log.info("==> 1. group-membership mapper on 'groups' scope")
+    kc.ensure_groups_mapper(config.realm)
+
+    log.info("==> 2. hub OIDC client + service account")
+    hub_uuid = kc.get_client_uuid(config.realm, config.hub_client_id)
+    kc.enable_service_accounts(config.realm, hub_uuid)
+    sa_user_id = kc.get_service_account_user_id(config.realm, hub_uuid)
+
+    log.info("==> 3. realm-management roles bound to hub SA")
+    kc.bind_realm_management_roles(config.realm, sa_user_id, REALM_MGMT_ROLES)
+
+    log.info("==> 4. shared-directory client role on hub client")
+    role_id = kc.ensure_client_role(
+        config.realm, hub_uuid, config.role_name, SHARED_DIR_ATTRIBUTES,
+    )
+
+    log.info("==> 5. assign role to configured groups")
+    for path in config.shared_mount_groups:
+        group_id = kc.get_group_id_by_path(config.realm, path)
+        if group_id is None:
+            log.warning("group path %r not found in realm; skipping", path)
+            continue
+        kc.assign_role_to_group(
+            config.realm, group_id, hub_uuid, role_id, config.role_name,
+        )
+
+    log.info("bootstrap complete")
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    try:
+        config = BootstrapConfig.from_env()
+    except KeyError as missing:
+        log.error("missing required env var: %s", missing)
+        return 2
+    kc = KCAdmin(config.kc_host, config.admin_password)
+    run(config, kc)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/keycloak-rbac-bootstrap-job.yaml
+++ b/templates/keycloak-rbac-bootstrap-job.yaml
@@ -1,20 +1,52 @@
 {{/*
-One-shot Helm hook that provisions the Keycloak realm config the hub
-needs for role-gated shared-mount RBAC.
+Keycloak realm bootstrap — runs once per chart install/upgrade.
 
-Runs on post-install AND post-upgrade so chart upgrades pick up newly
-added groups in ``rbac.bootstrap.sharedMountGroups``. Idempotent — every
-``kcadm create`` is followed by `|| true` and a "may already exist"
-log line so re-runs are clean.
+The actual logic lives in ``files/keycloak_rbac_bootstrap.py`` (a
+plain Python module using only the standard library, unit-tested in
+``tests/unit/test_keycloak_rbac_bootstrap.py``). The Helm chart's
+sole responsibility is to:
 
-Skipped entirely when ``rbac.bootstrap.enabled`` is false OR when
-``rbac.bootstrap.kcAdminCredentialSecret`` is empty (chart deploys
-fine without RBAC pre-configured).
+  1. ship that file into the cluster as a ConfigMap, and
+  2. run it inside a vanilla ``python:3.x-slim`` container with the
+     right env vars wired from chart values + the deployer-supplied
+     admin-password Secret.
+
+This split keeps the realm provisioning code out of YAML bash heredocs
+where it cannot be tested, linted, or single-stepped. Bumping the
+Python image tag forces a checksum-driven Job re-roll on the next
+chart upgrade.
+
+Gated on ``rbac.bootstrap.enabled`` AND the deployer providing a
+Secret reference for the KC admin password — the chart deploys
+fine without RBAC bootstrap pre-configured.
 */}}
 {{- if and .Values.rbac.bootstrap.enabled .Values.rbac.bootstrap.kcAdminCredentialSecret }}
 {{- if not .Values.rbac.bootstrap.hubClientId }}
 {{- fail "rbac.bootstrap.hubClientId must be set when rbac.bootstrap.enabled=true — the role + SA bindings attach to this Keycloak client." }}
 {{- end }}
+{{- $script := .Files.Get "files/keycloak_rbac_bootstrap.py" }}
+{{- if not $script }}
+{{- fail "files/keycloak_rbac_bootstrap.py missing from the chart — repackage with the file included." }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nebari-data-science-pack.fullname" . }}-rbac-bootstrap
+  {{- with .Values.rbac.bootstrap.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
+  labels:
+    {{- include "nebari-data-science-pack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  keycloak_rbac_bootstrap.py: |
+{{ $script | indent 4 }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,9 +60,14 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
-    # Keep the Job around after success so its logs are inspectable.
-    # Delete only before a fresh hook fires (next install/upgrade).
+    # Keep the Job around after success so its logs stay inspectable.
+    # Delete only before the next hook fires (next install/upgrade).
     "helm.sh/hook-delete-policy": before-hook-creation
+    # Force a re-run when the script content changes — Helm hook re-uses
+    # the same Job name across upgrades and would otherwise skip if the
+    # spec hash matches. Hash the script + values so a chart-only change
+    # also re-runs.
+    checksum/script: {{ $script | sha256sum }}
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 2
@@ -42,9 +79,14 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: kcadm
+        - name: bootstrap
           image: {{ .Values.rbac.bootstrap.image | quote }}
+          command:
+            - python
+            - /scripts/keycloak_rbac_bootstrap.py
           env:
+            - name: KC_HOST
+              value: {{ .Values.rbac.bootstrap.kcHost | quote }}
             - name: KC_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -58,137 +100,15 @@ spec:
               value: {{ .Values.rbac.bootstrap.sharedMountRoleName | quote }}
             - name: SHARED_MOUNT_GROUPS
               value: {{ .Values.rbac.bootstrap.sharedMountGroups | join "," | quote }}
-            - name: KC_HOST
-              value: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080"
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              KC=/opt/keycloak/bin/kcadm.sh
-              # Trace every command + xtrace so a failed bootstrap shows
-              # up at the first non-zero step rather than several echoed
-              # warnings later.
-              set -x
-              $KC config credentials --server "$KC_HOST" --realm master \
-                --user admin --password "$KC_ADMIN_PASSWORD" >/dev/null
-
-              echo "==> 1. Group-Membership mapper on the 'groups' client scope"
-              SID=$($KC get client-scopes -r "$REALM" --fields id,name 2>/dev/null \
-                | grep -B1 '"name" *: *"groups"' \
-                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-              if [ -z "$SID" ]; then
-                echo "creating 'groups' client scope..."
-                $KC create client-scopes -r "$REALM" \
-                  -s name=groups \
-                  -s protocol=openid-connect \
-                  -s 'attributes={"include.in.token.scope":"true","display.on.consent.screen":"true"}' || true
-                SID=$($KC get client-scopes -r "$REALM" --fields id,name \
-                  | grep -B1 '"name" *: *"groups"' \
-                  | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-              fi
-              if [ -n "$SID" ]; then
-                if $KC get "client-scopes/$SID/protocol-mappers/models" -r "$REALM" \
-                    | grep -q '"name" *: *"group-membership"'; then
-                  echo "  mapper already present"
-                else
-                  echo "  adding oidc-group-membership-mapper to scope $SID"
-                  $KC create "client-scopes/$SID/protocol-mappers/models" -r "$REALM" \
-                    -s name=group-membership \
-                    -s protocol=openid-connect \
-                    -s protocolMapper=oidc-group-membership-mapper \
-                    -s 'config={"full.path":"true","introspection.token.claim":"true","userinfo.token.claim":"true","id.token.claim":"true","access.token.claim":"true","claim.name":"groups"}' \
-                    || echo "  mapper create returned non-zero — may have raced; continuing"
-                fi
-                $KC update "realms/$REALM/default-default-client-scopes/$SID" -r "$REALM" || true
-              else
-                echo "  WARN: groups client scope absent and could not be created"
-              fi
-
-              echo "==> 2. Hub OIDC client lookup + serviceAccountsEnabled"
-              HUB_UUID=$($KC get clients -r "$REALM" -q clientId=$HUB_CLIENT_ID --fields id \
-                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-              if [ -z "$HUB_UUID" ]; then
-                echo "FATAL: hub client $HUB_CLIENT_ID not found in realm $REALM"
-                exit 1
-              fi
-              $KC update "clients/$HUB_UUID" -r "$REALM" -s serviceAccountsEnabled=true || true
-
-              echo "==> 3. Shared-mount client role on hub client"
-              if $KC get "clients/$HUB_UUID/roles/$ROLE_NAME" -r "$REALM" >/dev/null 2>&1; then
-                echo "  role $ROLE_NAME already exists; ensuring attributes"
-                $KC update "clients/$HUB_UUID/roles/$ROLE_NAME" -r "$REALM" \
-                  -s 'attributes={"component":["shared-directory"],"scopes":["write:shared-mount"]}' || true
-              else
-                $KC create "clients/$HUB_UUID/roles" -r "$REALM" \
-                  -s name=$ROLE_NAME \
-                  -s 'attributes={"component":["shared-directory"],"scopes":["write:shared-mount"]}' \
-                  || echo "  role create returned non-zero — may have raced; continuing"
-              fi
-
-              echo "==> 4. realm-management roles bound to hub client SA"
-              # Resolve realm-management client UUID and the hub
-              # client's SA user. The SA user only exists after
-              # ``serviceAccountsEnabled=true`` lands; the update
-              # above is synchronous in KC but defensively retry the
-              # SA lookup a few times before bailing.
-              REALM_MGMT_UUID=$($KC get clients -r "$REALM" -q clientId=realm-management --fields id \
-                | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-              SA_USER_ID=""
-              for _attempt in 1 2 3 4 5; do
-                SA_USER_ID=$($KC get "clients/$HUB_UUID/service-account-user" -r "$REALM" 2>/dev/null \
-                  | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-                [ -n "$SA_USER_ID" ] && break
-                sleep 2
-              done
-              if [ -z "$REALM_MGMT_UUID" ] || [ -z "$SA_USER_ID" ]; then
-                echo "  FATAL: realm-management ($REALM_MGMT_UUID) or hub SA ($SA_USER_ID) not resolvable"
-                exit 1
-              fi
-              for r in view-clients view-groups view-realm view-users; do
-                RID=$($KC get "clients/$REALM_MGMT_UUID/roles/$r" -r "$REALM" 2>/dev/null \
-                  | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-                if [ -z "$RID" ]; then
-                  echo "  WARN: role realm-management/$r not found"
-                  continue
-                fi
-                # POST is idempotent in KC; duplicate grants 409. The
-                # || true keeps the loop running.
-                $KC create "users/$SA_USER_ID/role-mappings/clients/$REALM_MGMT_UUID" -r "$REALM" \
-                  -b "[{\"id\":\"$RID\",\"name\":\"$r\"}]" \
-                  || echo "  realm-management/$r already bound"
-              done
-              # Verify so the Job log shows the final state.
-              echo "  hub SA realm-management roles after binding:"
-              $KC get "users/$SA_USER_ID/role-mappings/clients/$REALM_MGMT_UUID" -r "$REALM" \
-                --fields name 2>&1 | head -20
-
-              echo "==> 5. Assign shared-mount role to listed groups"
-              if [ -n "$SHARED_MOUNT_GROUPS" ]; then
-                ROLE_JSON=$($KC get "clients/$HUB_UUID/roles/$ROLE_NAME" -r "$REALM")
-                RID=$(echo "$ROLE_JSON" | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-                # Comma-separated -> newline-separated so a single IFS=
-                # split works without leaking back into the loop body.
-                echo "$SHARED_MOUNT_GROUPS" | tr ',' '\n' | while IFS= read -r GROUP_PATH; do
-                  [ -z "$GROUP_PATH" ] && continue
-                  # KC's ``group-by-path`` endpoint returns the group
-                  # object directly — single JSON, stable field
-                  # ordering. Replaces the previous search-then-sed
-                  # approach which broke when the search-result JSON
-                  # listed id BEFORE path so the path-anchored sed
-                  # range couldn't capture id retroactively.
-                  GROUP_PATH_NO_LEAD=$(echo "$GROUP_PATH" | sed 's|^/||')
-                  GID=$($KC get "group-by-path/$GROUP_PATH_NO_LEAD" -r "$REALM" --fields id 2>/dev/null \
-                    | sed -n 's/.*"id" *: *"\([^"]*\)".*/\1/p' | head -1)
-                  if [ -n "$GID" ]; then
-                    echo "  assigning $ROLE_NAME to group $GROUP_PATH (id=$GID)"
-                    $KC create "groups/$GID/role-mappings/clients/$HUB_UUID" -r "$REALM" \
-                      -b "[{\"id\":\"$RID\",\"name\":\"$ROLE_NAME\"}]" \
-                      || echo "  group $GROUP_PATH already has role"
-                  else
-                    echo "  WARN: group $GROUP_PATH not found in realm; skipping"
-                  fi
-                done
-              fi
-
-              echo "==> rbac bootstrap done."
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: {{ include "nebari-data-science-pack.fullname" . }}-rbac-bootstrap
+            defaultMode: 0o0555
 {{- end }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,27 @@
+"""Integration tests run against a real Keycloak.
+
+The sibling fixture file makes the bootstrap module importable without
+pulling ``files/`` onto ``sys.path`` permanently. Tests then talk to a
+live KC over HTTP — there is no in-process fake here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "files" / "keycloak_rbac_bootstrap.py"
+
+
+def _load_rbac():
+    spec = importlib.util.spec_from_file_location("rbac_bootstrap", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["rbac_bootstrap"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+rbac = _load_rbac()

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli = true
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)s] %(name)s: %(message)s
+log_cli_date_format = %H:%M:%S

--- a/tests/integration/test_keycloak_rbac_bootstrap.py
+++ b/tests/integration/test_keycloak_rbac_bootstrap.py
@@ -47,7 +47,6 @@ from conftest import rbac
 
 log = logging.getLogger("rbac-integration")
 
-REALM = "nebari"
 ROLE_NAME = "allow-group-directory-creation-role"
 
 
@@ -82,6 +81,27 @@ def kc(kc_url, kc_admin_password):
     return client
 
 
+@pytest.fixture(scope="module")
+def realm(kc: rbac.KCAdmin) -> Iterator[str]:
+    """Create a throwaway realm so the tests don't depend on the
+    deployer-provisioned ``nebari`` realm being ready (NIC's realm
+    setup is an async PostSync hook in the sandbox profile and the
+    timing isn't guaranteed). KC auto-creates the ``groups``
+    client-scope on every new realm, so the bootstrap exercises the
+    same code path it does on a real install.
+    """
+    name = f"test-{uuid.uuid4().hex[:10]}"
+    log.info("creating throwaway realm %s", name)
+    kc._request("POST", "", body={"realm": name, "enabled": True})
+    try:
+        yield name
+    finally:
+        try:
+            kc._request("DELETE", f"/{name}")
+        except Exception as exc:  # noqa: BLE001 — diagnostic only
+            log.warning("realm cleanup DELETE %s failed: %s", name, exc)
+
+
 # ---------------------------------------------------------------------------
 # Per-test scratch realm objects
 # ---------------------------------------------------------------------------
@@ -100,8 +120,8 @@ def _suffix() -> str:
 
 
 @pytest.fixture
-def scratch(kc: rbac.KCAdmin) -> Iterator[Scratch]:
-    """Create a throwaway OIDC client + group in the nebari realm.
+def scratch(kc: rbac.KCAdmin, realm: str) -> Iterator[Scratch]:
+    """Create a throwaway OIDC client + group in the test realm.
 
     Bootstrap operates on whatever ``hubClientId`` the deployer hands
     it, so any KC client will do — the test client need not look like
@@ -115,7 +135,7 @@ def scratch(kc: rbac.KCAdmin) -> Iterator[Scratch]:
     log.info("creating scratch client %s and group %s", client_id, group_path)
     kc._request(
         "POST",
-        f"/{REALM}/clients",
+        f"/{realm}/clients",
         body={
             "clientId": client_id,
             "protocol": "openid-connect",
@@ -124,14 +144,14 @@ def scratch(kc: rbac.KCAdmin) -> Iterator[Scratch]:
             "standardFlowEnabled": True,
         },
     )
-    client_uuid = kc.get_client_uuid(REALM, client_id)
+    client_uuid = kc.get_client_uuid(realm, client_id)
 
-    group = kc._request(
+    kc._request(
         "POST",
-        f"/{REALM}/groups",
+        f"/{realm}/groups",
         body={"name": group_path.lstrip("/")},
     )
-    group_id = kc.get_group_id_by_path(REALM, group_path)
+    group_id = kc.get_group_id_by_path(realm, group_path)
     assert group_id is not None, f"group {group_path} not created"
 
     yield Scratch(client_id, client_uuid, group_path, group_id)
@@ -139,8 +159,8 @@ def scratch(kc: rbac.KCAdmin) -> Iterator[Scratch]:
     # Best-effort cleanup. Test failures should leave artifacts in place
     # for diagnosis; CI tears down the whole cluster.
     for method, path in (
-        ("DELETE", f"/{REALM}/clients/{client_uuid}"),
-        ("DELETE", f"/{REALM}/groups/{group_id}"),
+        ("DELETE", f"/{realm}/clients/{client_uuid}"),
+        ("DELETE", f"/{realm}/groups/{group_id}"),
     ):
         try:
             kc._request(method, path)
@@ -148,12 +168,13 @@ def scratch(kc: rbac.KCAdmin) -> Iterator[Scratch]:
             log.warning("cleanup %s %s failed: %s", method, path, exc)
 
 
-def _config_for(scratch: Scratch, kc_url: str, kc_admin_password: str,
+def _config_for(scratch: Scratch, realm: str, kc_url: str,
+                kc_admin_password: str,
                 groups: tuple[str, ...] = ()) -> rbac.BootstrapConfig:
     return rbac.BootstrapConfig(
         kc_host=kc_url,
         admin_password=kc_admin_password,
-        realm=REALM,
+        realm=realm,
         hub_client_id=scratch.client_id,
         role_name=ROLE_NAME,
         shared_mount_groups=groups or (scratch.group_path,),
@@ -166,32 +187,32 @@ def _config_for(scratch: Scratch, kc_url: str, kc_admin_password: str,
 
 
 def test_fresh_provision_applies_every_step(
-    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password,
+    kc: rbac.KCAdmin, realm: str, scratch: Scratch, kc_url, kc_admin_password,
 ):
     """End-to-end happy path on a freshly-created client + group."""
-    cfg = _config_for(scratch, kc_url, kc_admin_password)
+    cfg = _config_for(scratch, realm, kc_url, kc_admin_password)
     rbac.run(cfg, rbac.KCAdmin(kc_url, kc_admin_password))
 
     # 1. groups scope has a group-membership mapper.
-    scope_id = kc.get_client_scope_id(REALM, "groups")
-    assert scope_id is not None, "nebari realm should ship a 'groups' client-scope"
+    scope_id = kc.get_client_scope_id(realm, "groups")
+    assert scope_id is not None, "realm should ship a 'groups' client-scope"
     mappers = kc._request(
-        "GET", f"/{REALM}/client-scopes/{scope_id}/protocol-mappers/models",
+        "GET", f"/{realm}/client-scopes/{scope_id}/protocol-mappers/models",
     ) or []
     assert any(m["name"] == "group-membership" for m in mappers), (
         "bootstrap must add an oidc-group-membership-mapper to 'groups'"
     )
 
     # 2. serviceAccountsEnabled flipped on the hub client.
-    client = kc._request("GET", f"/{REALM}/clients/{scratch.client_uuid}")
+    client = kc._request("GET", f"/{realm}/clients/{scratch.client_uuid}")
     assert client["serviceAccountsEnabled"] is True
 
     # 3. Realm-management roles bound to the SA user.
-    sa_user_id = kc.get_service_account_user_id(REALM, scratch.client_uuid)
-    rm_uuid = kc.get_client_uuid(REALM, "realm-management")
+    sa_user_id = kc.get_service_account_user_id(realm, scratch.client_uuid)
+    rm_uuid = kc.get_client_uuid(realm, "realm-management")
     bindings = kc._request(
         "GET",
-        f"/{REALM}/users/{sa_user_id}/role-mappings/clients/{rm_uuid}",
+        f"/{realm}/users/{sa_user_id}/role-mappings/clients/{rm_uuid}",
     ) or []
     bound = {b["name"] for b in bindings}
     assert set(rbac.REALM_MGMT_ROLES).issubset(bound), (
@@ -201,14 +222,14 @@ def test_fresh_provision_applies_every_step(
 
     # 4. The shared-directory client role exists with the required attrs.
     role = kc._request(
-        "GET", f"/{REALM}/clients/{scratch.client_uuid}/roles/{ROLE_NAME}",
+        "GET", f"/{realm}/clients/{scratch.client_uuid}/roles/{ROLE_NAME}",
     )
     assert role["attributes"] == rbac.SHARED_DIR_ATTRIBUTES
 
     # 5. The scratch group has the role assigned.
     group_bindings = kc._request(
         "GET",
-        f"/{REALM}/groups/{scratch.group_id}"
+        f"/{realm}/groups/{scratch.group_id}"
         f"/role-mappings/clients/{scratch.client_uuid}",
     ) or []
     assert any(b["name"] == ROLE_NAME for b in group_bindings), (
@@ -217,13 +238,13 @@ def test_fresh_provision_applies_every_step(
 
 
 def test_second_run_makes_no_mutating_calls(
-    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password,
+    kc: rbac.KCAdmin, realm: str, scratch: Scratch, kc_url, kc_admin_password,
 ):
     """Helm runs the Job on every install AND every upgrade. The second
     invocation MUST be read-only — otherwise every chart upgrade
     produces audit-log noise and risks reverting deployer overrides.
     """
-    cfg = _config_for(scratch, kc_url, kc_admin_password)
+    cfg = _config_for(scratch, realm, kc_url, kc_admin_password)
     rbac.run(cfg, rbac.KCAdmin(kc_url, kc_admin_password))
 
     # Wrap _request to record every call the second pass makes.
@@ -245,7 +266,7 @@ def test_second_run_makes_no_mutating_calls(
 
 
 def test_role_attribute_drift_is_reconciled(
-    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password,
+    kc: rbac.KCAdmin, realm: str, scratch: Scratch, kc_url, kc_admin_password,
 ):
     """A pre-existing role with wrong attributes must be PUT back to
     the desired pair. Without reconciliation, the hub's KCRealmAdmin
@@ -257,18 +278,18 @@ def test_role_attribute_drift_is_reconciled(
     # the GET-before-create path and has to PUT to fix it.
     kc._request(
         "POST",
-        f"/{REALM}/clients/{scratch.client_uuid}/roles",
+        f"/{realm}/clients/{scratch.client_uuid}/roles",
         body={
             "name": ROLE_NAME,
             "attributes": {"component": ["wrong-component"]},
         },
     )
 
-    cfg = _config_for(scratch, kc_url, kc_admin_password)
+    cfg = _config_for(scratch, realm, kc_url, kc_admin_password)
     rbac.run(cfg, rbac.KCAdmin(kc_url, kc_admin_password))
 
     role = kc._request(
-        "GET", f"/{REALM}/clients/{scratch.client_uuid}/roles/{ROLE_NAME}",
+        "GET", f"/{realm}/clients/{scratch.client_uuid}/roles/{ROLE_NAME}",
     )
     assert role["attributes"] == rbac.SHARED_DIR_ATTRIBUTES, (
         f"role attrs not reconciled; got {role['attributes']!r}"
@@ -276,7 +297,8 @@ def test_role_attribute_drift_is_reconciled(
 
 
 def test_unknown_group_path_is_skipped(
-    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password, caplog,
+    kc: rbac.KCAdmin, realm: str, scratch: Scratch,
+    kc_url, kc_admin_password, caplog,
 ):
     """Deployer typo in ``sharedMountGroups``: bootstrap must continue
     with the other (real) groups rather than abort and leave the realm
@@ -286,7 +308,7 @@ def test_unknown_group_path_is_skipped(
     """
     fake_path = f"/no-such-group-{_suffix()}"
     cfg = _config_for(
-        scratch, kc_url, kc_admin_password,
+        scratch, realm, kc_url, kc_admin_password,
         groups=(scratch.group_path, fake_path),
     )
 
@@ -301,7 +323,7 @@ def test_unknown_group_path_is_skipped(
     # Real group still got the role.
     bindings = kc._request(
         "GET",
-        f"/{REALM}/groups/{scratch.group_id}"
+        f"/{realm}/groups/{scratch.group_id}"
         f"/role-mappings/clients/{scratch.client_uuid}",
     ) or []
     assert any(b["name"] == ROLE_NAME for b in bindings)

--- a/tests/integration/test_keycloak_rbac_bootstrap.py
+++ b/tests/integration/test_keycloak_rbac_bootstrap.py
@@ -1,0 +1,307 @@
+"""End-to-end tests for ``files/keycloak_rbac_bootstrap.py`` against a
+real Keycloak.
+
+Spun up in CI by ``nebari-dev/action-nebari-sandbox`` (platform
+profile), which deploys NIC's foundational stack — Keycloak + a
+``nebari`` realm. The runner forwards ``localhost:18080`` to the
+in-cluster ``keycloak-keycloakx-http`` service; this module reads
+``KC_URL`` and ``KC_ADMIN_PASSWORD`` from the env and talks to that
+endpoint over plain HTTP.
+
+Why these tests exist:
+
+The unit tests pin orchestration against an in-memory fake. They will
+not catch KC version skew (e.g. an endpoint moves under
+``/auth/admin/...``, a payload field gets renamed, a 4xx status is
+emitted where the fake returned 2xx). These tests do — at the cost of
+needing a live KC.
+
+What's tested:
+
+* Fresh provisioning end-to-end: groups-mapper, SA enable, RM role
+  bindings, hub-side client role with required attributes, group→role
+  assignment.
+* Idempotency: a second run produces NO mutating POST/PUT calls.
+* Attribute drift on the role: bootstrap PUTs the desired attribute
+  pair back.
+* Unknown group path: logged and skipped, real groups still get the
+  role.
+
+Each test gets its own freshly-created OIDC client + KC group with a
+UUID suffix so they cannot collide with each other or with prior runs.
+Cleanup is best-effort on teardown — Keycloak in CI is throwaway.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from conftest import rbac
+
+
+log = logging.getLogger("rbac-integration")
+
+REALM = "nebari"
+ROLE_NAME = "allow-group-directory-creation-role"
+
+
+# ---------------------------------------------------------------------------
+# Live KC connection — module-scoped so we only password-grant once.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def kc_url() -> str:
+    url = os.environ.get("KC_URL")
+    if not url:
+        pytest.skip("KC_URL not set — these tests need a live Keycloak")
+    return url.rstrip("/")
+
+
+@pytest.fixture(scope="module")
+def kc_admin_password() -> str:
+    pw = os.environ.get("KC_ADMIN_PASSWORD")
+    if not pw:
+        pytest.skip("KC_ADMIN_PASSWORD not set")
+    return pw
+
+
+@pytest.fixture(scope="module")
+def kc(kc_url, kc_admin_password):
+    """Authenticated admin client against the master realm."""
+    client = rbac.KCAdmin(kc_url, kc_admin_password)
+    # Force a token grant up-front so a misconfigured CI surfaces the
+    # auth failure here (one place), not inside every test.
+    client._token_now()
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Per-test scratch realm objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Scratch:
+    client_id: str
+    client_uuid: str
+    group_path: str
+    group_id: str
+
+
+def _suffix() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+@pytest.fixture
+def scratch(kc: rbac.KCAdmin) -> Iterator[Scratch]:
+    """Create a throwaway OIDC client + group in the nebari realm.
+
+    Bootstrap operates on whatever ``hubClientId`` the deployer hands
+    it, so any KC client will do — the test client need not look like
+    a real hub. The group path mirrors the production convention so
+    ``get_group_id_by_path`` exercises the same code path.
+    """
+    suffix = _suffix()
+    client_id = f"test-hub-{suffix}"
+    group_path = f"/test-{suffix}"
+
+    log.info("creating scratch client %s and group %s", client_id, group_path)
+    kc._request(
+        "POST",
+        f"/{REALM}/clients",
+        body={
+            "clientId": client_id,
+            "protocol": "openid-connect",
+            "publicClient": False,
+            "serviceAccountsEnabled": False,
+            "standardFlowEnabled": True,
+        },
+    )
+    client_uuid = kc.get_client_uuid(REALM, client_id)
+
+    group = kc._request(
+        "POST",
+        f"/{REALM}/groups",
+        body={"name": group_path.lstrip("/")},
+    )
+    group_id = kc.get_group_id_by_path(REALM, group_path)
+    assert group_id is not None, f"group {group_path} not created"
+
+    yield Scratch(client_id, client_uuid, group_path, group_id)
+
+    # Best-effort cleanup. Test failures should leave artifacts in place
+    # for diagnosis; CI tears down the whole cluster.
+    for method, path in (
+        ("DELETE", f"/{REALM}/clients/{client_uuid}"),
+        ("DELETE", f"/{REALM}/groups/{group_id}"),
+    ):
+        try:
+            kc._request(method, path)
+        except Exception as exc:  # noqa: BLE001 — diagnostic only
+            log.warning("cleanup %s %s failed: %s", method, path, exc)
+
+
+def _config_for(scratch: Scratch, kc_url: str, kc_admin_password: str,
+                groups: tuple[str, ...] = ()) -> rbac.BootstrapConfig:
+    return rbac.BootstrapConfig(
+        kc_host=kc_url,
+        admin_password=kc_admin_password,
+        realm=REALM,
+        hub_client_id=scratch.client_id,
+        role_name=ROLE_NAME,
+        shared_mount_groups=groups or (scratch.group_path,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_provision_applies_every_step(
+    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password,
+):
+    """End-to-end happy path on a freshly-created client + group."""
+    cfg = _config_for(scratch, kc_url, kc_admin_password)
+    rbac.run(cfg, rbac.KCAdmin(kc_url, kc_admin_password))
+
+    # 1. groups scope has a group-membership mapper.
+    scope_id = kc.get_client_scope_id(REALM, "groups")
+    assert scope_id is not None, "nebari realm should ship a 'groups' client-scope"
+    mappers = kc._request(
+        "GET", f"/{REALM}/client-scopes/{scope_id}/protocol-mappers/models",
+    ) or []
+    assert any(m["name"] == "group-membership" for m in mappers), (
+        "bootstrap must add an oidc-group-membership-mapper to 'groups'"
+    )
+
+    # 2. serviceAccountsEnabled flipped on the hub client.
+    client = kc._request("GET", f"/{REALM}/clients/{scratch.client_uuid}")
+    assert client["serviceAccountsEnabled"] is True
+
+    # 3. Realm-management roles bound to the SA user.
+    sa_user_id = kc.get_service_account_user_id(REALM, scratch.client_uuid)
+    rm_uuid = kc.get_client_uuid(REALM, "realm-management")
+    bindings = kc._request(
+        "GET",
+        f"/{REALM}/users/{sa_user_id}/role-mappings/clients/{rm_uuid}",
+    ) or []
+    bound = {b["name"] for b in bindings}
+    assert set(rbac.REALM_MGMT_ROLES).issubset(bound), (
+        f"SA missing realm-management roles; have {bound}, "
+        f"want {rbac.REALM_MGMT_ROLES}"
+    )
+
+    # 4. The shared-directory client role exists with the required attrs.
+    role = kc._request(
+        "GET", f"/{REALM}/clients/{scratch.client_uuid}/roles/{ROLE_NAME}",
+    )
+    assert role["attributes"] == rbac.SHARED_DIR_ATTRIBUTES
+
+    # 5. The scratch group has the role assigned.
+    group_bindings = kc._request(
+        "GET",
+        f"/{REALM}/groups/{scratch.group_id}"
+        f"/role-mappings/clients/{scratch.client_uuid}",
+    ) or []
+    assert any(b["name"] == ROLE_NAME for b in group_bindings), (
+        f"role {ROLE_NAME} not assigned to group {scratch.group_path}"
+    )
+
+
+def test_second_run_makes_no_mutating_calls(
+    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password,
+):
+    """Helm runs the Job on every install AND every upgrade. The second
+    invocation MUST be read-only — otherwise every chart upgrade
+    produces audit-log noise and risks reverting deployer overrides.
+    """
+    cfg = _config_for(scratch, kc_url, kc_admin_password)
+    rbac.run(cfg, rbac.KCAdmin(kc_url, kc_admin_password))
+
+    # Wrap _request to record every call the second pass makes.
+    second_kc = rbac.KCAdmin(kc_url, kc_admin_password)
+    calls: list[tuple[str, str]] = []
+    real_request = second_kc._request
+
+    def recording(method, path, **kw):
+        calls.append((method, path))
+        return real_request(method, path, **kw)
+
+    second_kc._request = recording  # type: ignore[method-assign]
+    rbac.run(cfg, second_kc)
+
+    mutating = [c for c in calls if c[0] in ("POST", "PUT", "DELETE")]
+    assert mutating == [], (
+        f"second run must be read-only; got mutating calls: {mutating}"
+    )
+
+
+def test_role_attribute_drift_is_reconciled(
+    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password,
+):
+    """A pre-existing role with wrong attributes must be PUT back to
+    the desired pair. Without reconciliation, the hub's KCRealmAdmin
+    sees 'no required attrs' and silently returns an empty
+    ``groups_with_permission_to_mount`` filter — the role looks bound
+    but does nothing.
+    """
+    # Pre-seed the role with bad attributes so bootstrap finds it on
+    # the GET-before-create path and has to PUT to fix it.
+    kc._request(
+        "POST",
+        f"/{REALM}/clients/{scratch.client_uuid}/roles",
+        body={
+            "name": ROLE_NAME,
+            "attributes": {"component": ["wrong-component"]},
+        },
+    )
+
+    cfg = _config_for(scratch, kc_url, kc_admin_password)
+    rbac.run(cfg, rbac.KCAdmin(kc_url, kc_admin_password))
+
+    role = kc._request(
+        "GET", f"/{REALM}/clients/{scratch.client_uuid}/roles/{ROLE_NAME}",
+    )
+    assert role["attributes"] == rbac.SHARED_DIR_ATTRIBUTES, (
+        f"role attrs not reconciled; got {role['attributes']!r}"
+    )
+
+
+def test_unknown_group_path_is_skipped(
+    kc: rbac.KCAdmin, scratch: Scratch, kc_url, kc_admin_password, caplog,
+):
+    """Deployer typo in ``sharedMountGroups``: bootstrap must continue
+    with the other (real) groups rather than abort and leave the realm
+    half-configured. The Helm Job exit code feeds Argo health; a hard
+    failure here would block every chart upgrade until somebody fixes
+    the typo.
+    """
+    fake_path = f"/no-such-group-{_suffix()}"
+    cfg = _config_for(
+        scratch, kc_url, kc_admin_password,
+        groups=(scratch.group_path, fake_path),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="rbac-bootstrap"):
+        rbac.run(cfg, rbac.KCAdmin(kc_url, kc_admin_password))
+
+    assert any(fake_path in r.message for r in caplog.records), (
+        f"expected WARNING mentioning {fake_path}; got "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+    # Real group still got the role.
+    bindings = kc._request(
+        "GET",
+        f"/{REALM}/groups/{scratch.group_id}"
+        f"/role-mappings/clients/{scratch.client_uuid}",
+    ) or []
+    assert any(b["name"] == ROLE_NAME for b in bindings)

--- a/tests/integration/test_keycloak_rbac_bootstrap.py
+++ b/tests/integration/test_keycloak_rbac_bootstrap.py
@@ -208,16 +208,31 @@ def test_fresh_provision_applies_every_step(
     assert client["serviceAccountsEnabled"] is True
 
     # 3. Realm-management roles bound to the SA user.
+    #
+    # Some role names in REALM_MGMT_ROLES were renamed/merged in newer
+    # KC versions (e.g. ``view-groups`` is absent in KC 26.x). The
+    # bootstrap intentionally skips roles that don't exist on this KC
+    # — what we pin here is "every role the script *could* bind, it
+    # *did* bind." Compute that subset from the live realm-management
+    # client rather than hardcoding to a specific KC version.
     sa_user_id = kc.get_service_account_user_id(realm, scratch.client_uuid)
     rm_uuid = kc.get_client_uuid(realm, "realm-management")
+    available = {
+        r["name"]
+        for r in (kc._request("GET", f"/{realm}/clients/{rm_uuid}/roles") or [])
+    }
+    expected = set(rbac.REALM_MGMT_ROLES) & available
+    assert expected, (
+        f"realm-management client has none of {rbac.REALM_MGMT_ROLES} — "
+        f"KC role-name list has drifted, the bootstrap needs updating"
+    )
     bindings = kc._request(
         "GET",
         f"/{realm}/users/{sa_user_id}/role-mappings/clients/{rm_uuid}",
     ) or []
     bound = {b["name"] for b in bindings}
-    assert set(rbac.REALM_MGMT_ROLES).issubset(bound), (
-        f"SA missing realm-management roles; have {bound}, "
-        f"want {rbac.REALM_MGMT_ROLES}"
+    assert expected.issubset(bound), (
+        f"SA missing realm-management roles; have {bound}, want {expected}"
     )
 
     # 4. The shared-directory client role exists with the required attrs.

--- a/tests/unit/test_keycloak_rbac_bootstrap.py
+++ b/tests/unit/test_keycloak_rbac_bootstrap.py
@@ -1,37 +1,29 @@
-"""Unit tests for the Keycloak RBAC bootstrap script.
+"""Unit tests for the Keycloak RBAC bootstrap orchestrator.
 
-Public contract being pinned:
+These tests pin the high-level control flow of :func:`run` against an
+in-memory fake of the KC Admin API. They are fast (no network) and
+catch logic regressions early in dev / pre-push.
 
-* Each step in :func:`run` is idempotent — given a Keycloak that
-  already has the desired state, the second call MUST make no
-  state-changing API requests (no POST, no PUT, no DELETE).
-* On a fresh realm, the script provisions: ``groups`` client scope
-  mapper, hub OIDC client serviceAccountsEnabled flag,
-  realm-management roles on the hub SA, the shared-directory client
-  role with the required attribute pair, and group→role assignment
-  for each configured KC group path.
-* Group paths that don't exist in the realm are logged as warnings
-  and skipped, NOT raised — the Helm Job must succeed even when the
-  deployer's ``sharedMountGroups`` list contains a typo.
+The corresponding integration tests in ``tests/integration/`` exercise
+the same orchestrator against a real Keycloak — those catch KC version
+skew, JSON quirks, and transport bugs the fake will never see. Unit
+tests cover orchestration; integration tests cover reality. Both are
+required.
 
 Tests mock at the HTTP-method boundary (:py:meth:`KCAdmin._request`)
-rather than at ``urllib.request``. That keeps the assertions focused
-on what the script DOES (which KC endpoints it hits, with what
-bodies) rather than on transport plumbing, and survives any change
-to how :py:meth:`KCAdmin._request` is implemented.
+rather than at ``urllib.request``: assertions stay focused on which KC
+endpoints are hit and with what bodies, and survive any change to how
+:py:meth:`KCAdmin._request` is implemented.
 """
 
 from __future__ import annotations
 
 import importlib.util
-import json
 import sys
 import urllib.error
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock
-
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -58,46 +50,6 @@ def http_404() -> urllib.error.HTTPError:
         url="http://kc.test/", code=404, msg="Not Found", hdrs=None,
         fp=BytesIO(b""),
     )
-
-
-# ---------------------------------------------------------------------------
-# BootstrapConfig.from_env
-# ---------------------------------------------------------------------------
-
-def test_bootstrap_config_parses_env_and_splits_groups_csv():
-    """Config carries everything ``run`` needs in a frozen dataclass —
-    no hidden globals, no ``os.environ`` access deep in the call tree.
-    Groups arrive as a comma-separated string from the Helm template
-    (where the user supplies a list) and split into a tuple of paths."""
-    env = {
-        "KC_HOST": "http://kc.test",
-        "KC_ADMIN_PASSWORD": "p",
-        "REALM": "nebari",
-        "HUB_CLIENT_ID": "hub",
-        "ROLE_NAME": "allow-group-directory-creation-role",
-        "SHARED_MOUNT_GROUPS": "/admin,/developer",
-    }
-    cfg = rbac.BootstrapConfig.from_env(env)
-    assert cfg.shared_mount_groups == ("/admin", "/developer")
-    assert cfg.realm == "nebari"
-    assert cfg.kc_host == "http://kc.test"
-
-
-def test_bootstrap_config_empty_groups_string_becomes_empty_tuple():
-    """Deployer leaves ``sharedMountGroups: []`` → empty CSV. Must not
-    inject a single empty-string group path."""
-    env = {
-        "KC_HOST": "x", "KC_ADMIN_PASSWORD": "p", "REALM": "r",
-        "HUB_CLIENT_ID": "h", "ROLE_NAME": "r", "SHARED_MOUNT_GROUPS": "",
-    }
-    assert rbac.BootstrapConfig.from_env(env).shared_mount_groups == ()
-
-
-def test_bootstrap_config_missing_required_env_raises_keyerror():
-    """``KeyError`` on missing var so ``main()`` returns exit code 2
-    instead of crashing mid-bootstrap with a half-applied realm."""
-    with pytest.raises(KeyError):
-        rbac.BootstrapConfig.from_env({"KC_HOST": "x"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_keycloak_rbac_bootstrap.py
+++ b/tests/unit/test_keycloak_rbac_bootstrap.py
@@ -1,0 +1,425 @@
+"""Unit tests for the Keycloak RBAC bootstrap script.
+
+Public contract being pinned:
+
+* Each step in :func:`run` is idempotent — given a Keycloak that
+  already has the desired state, the second call MUST make no
+  state-changing API requests (no POST, no PUT, no DELETE).
+* On a fresh realm, the script provisions: ``groups`` client scope
+  mapper, hub OIDC client serviceAccountsEnabled flag,
+  realm-management roles on the hub SA, the shared-directory client
+  role with the required attribute pair, and group→role assignment
+  for each configured KC group path.
+* Group paths that don't exist in the realm are logged as warnings
+  and skipped, NOT raised — the Helm Job must succeed even when the
+  deployer's ``sharedMountGroups`` list contains a typo.
+
+Tests mock at the HTTP-method boundary (:py:meth:`KCAdmin._request`)
+rather than at ``urllib.request``. That keeps the assertions focused
+on what the script DOES (which KC endpoints it hits, with what
+bodies) rather than on transport plumbing, and survives any change
+to how :py:meth:`KCAdmin._request` is implemented.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "files" / "keycloak_rbac_bootstrap.py"
+spec = importlib.util.spec_from_file_location("rbac_bootstrap", SCRIPT_PATH)
+rbac = importlib.util.module_from_spec(spec)
+sys.modules["rbac_bootstrap"] = rbac
+spec.loader.exec_module(rbac)
+
+
+REALM = "nebari"
+HUB_CLIENT_ID = "jupyterhub-hub-client"
+HUB_UUID = "00000000-0000-0000-0000-000000000001"
+SA_USER_ID = "00000000-0000-0000-0000-00000000aaaa"
+RM_UUID = "00000000-0000-0000-0000-00000000bbbb"
+ROLE_NAME = "allow-group-directory-creation-role"
+ROLE_ID = "00000000-0000-0000-0000-00000000cccc"
+ADMIN_GROUP_PATH = "/admin"
+ADMIN_GROUP_ID = "00000000-0000-0000-0000-00000000dddd"
+
+
+def http_404() -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="http://kc.test/", code=404, msg="Not Found", hdrs=None,
+        fp=BytesIO(b""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# BootstrapConfig.from_env
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_config_parses_env_and_splits_groups_csv():
+    """Config carries everything ``run`` needs in a frozen dataclass —
+    no hidden globals, no ``os.environ`` access deep in the call tree.
+    Groups arrive as a comma-separated string from the Helm template
+    (where the user supplies a list) and split into a tuple of paths."""
+    env = {
+        "KC_HOST": "http://kc.test",
+        "KC_ADMIN_PASSWORD": "p",
+        "REALM": "nebari",
+        "HUB_CLIENT_ID": "hub",
+        "ROLE_NAME": "allow-group-directory-creation-role",
+        "SHARED_MOUNT_GROUPS": "/admin,/developer",
+    }
+    cfg = rbac.BootstrapConfig.from_env(env)
+    assert cfg.shared_mount_groups == ("/admin", "/developer")
+    assert cfg.realm == "nebari"
+    assert cfg.kc_host == "http://kc.test"
+
+
+def test_bootstrap_config_empty_groups_string_becomes_empty_tuple():
+    """Deployer leaves ``sharedMountGroups: []`` → empty CSV. Must not
+    inject a single empty-string group path."""
+    env = {
+        "KC_HOST": "x", "KC_ADMIN_PASSWORD": "p", "REALM": "r",
+        "HUB_CLIENT_ID": "h", "ROLE_NAME": "r", "SHARED_MOUNT_GROUPS": "",
+    }
+    assert rbac.BootstrapConfig.from_env(env).shared_mount_groups == ()
+
+
+def test_bootstrap_config_missing_required_env_raises_keyerror():
+    """``KeyError`` on missing var so ``main()`` returns exit code 2
+    instead of crashing mid-bootstrap with a half-applied realm."""
+    with pytest.raises(KeyError):
+        rbac.BootstrapConfig.from_env({"KC_HOST": "x"})
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a KCAdmin with _request fully mocked
+# ---------------------------------------------------------------------------
+
+def make_kc(request_side_effect):
+    """Build a KCAdmin instance with ``_request`` replaced by a
+    side-effect that takes ``(method, path, body=None, accept_409=False)``
+    and returns the parsed response."""
+    kc = rbac.KCAdmin("http://kc.test", "admin-password")
+    kc._request = MagicMock(side_effect=request_side_effect)
+    return kc
+
+
+def _fake_realm(state):
+    """Return a callable suitable for ``KCAdmin._request`` side_effect
+    that serves the given in-memory realm state. Subsequent mutating
+    calls update ``state`` so the same fixture supports idempotency
+    tests across two passes."""
+
+    def respond(method, path, *, body=None, accept_409=False):
+        # GET /<realm>/client-scopes
+        if method == "GET" and path == f"/{REALM}/client-scopes":
+            return state["client_scopes"]
+        # GET /<realm>/client-scopes/<id>/protocol-mappers/models
+        if method == "GET" and path.endswith("/protocol-mappers/models"):
+            scope_id = path.split("/")[-3]
+            return state["mappers"].get(scope_id, [])
+        # POST /<realm>/client-scopes/<id>/protocol-mappers/models
+        if method == "POST" and path.endswith("/protocol-mappers/models"):
+            scope_id = path.split("/")[-3]
+            state["mappers"].setdefault(scope_id, []).append(body)
+            return None
+        # GET /<realm>/clients?clientId=<id>
+        if method == "GET" and path.startswith(f"/{REALM}/clients?clientId="):
+            cid = path.rsplit("=", 1)[1]
+            return [c for c in state["clients"] if c["clientId"] == cid]
+        # GET /<realm>/clients/<uuid>
+        if (
+            method == "GET"
+            and path.startswith(f"/{REALM}/clients/")
+            and "/roles" not in path
+            and "/service-account-user" not in path
+        ):
+            uuid = path.split("/")[-1]
+            for c in state["clients"]:
+                if c["id"] == uuid:
+                    return dict(c)
+            raise http_404()
+        # PUT /<realm>/clients/<uuid>  (full-object update)
+        if method == "PUT" and path == f"/{REALM}/clients/{HUB_UUID}":
+            for c in state["clients"]:
+                if c["id"] == HUB_UUID:
+                    c.update(body)
+                    return None
+        # GET /<realm>/clients/<uuid>/service-account-user
+        if method == "GET" and path.endswith("/service-account-user"):
+            sa = state.get("service_account_user")
+            if sa is None:
+                raise http_404()
+            return sa
+        # GET /<realm>/clients/<uuid>/roles/<name>
+        if (
+            method == "GET"
+            and "/clients/" in path
+            and "/roles/" in path
+            and "/groups" not in path
+        ):
+            client_uuid = path.split("/")[3]
+            role_name = path.split("/")[-1]
+            roles = state["client_roles"].get(client_uuid, {})
+            if role_name not in roles:
+                raise http_404()
+            return dict(roles[role_name])
+        # POST /<realm>/clients/<uuid>/roles  (create)
+        if method == "POST" and path == f"/{REALM}/clients/{HUB_UUID}/roles":
+            state["client_roles"].setdefault(HUB_UUID, {})[body["name"]] = {
+                "id": ROLE_ID,
+                "name": body["name"],
+                "attributes": body.get("attributes", {}),
+            }
+            return None
+        # PUT role  (attribute reconcile)
+        if (
+            method == "PUT"
+            and "/clients/" in path
+            and "/roles/" in path
+        ):
+            role_name = path.split("/")[-1]
+            client_uuid = path.split("/")[3]
+            state["client_roles"][client_uuid][role_name] = dict(body)
+            return None
+        # GET /<realm>/users/<sa>/role-mappings/clients/<rm>
+        if (
+            method == "GET"
+            and "/users/" in path
+            and "/role-mappings/clients/" in path
+        ):
+            return list(state.get("sa_role_bindings", []))
+        # POST role bindings on SA
+        if (
+            method == "POST"
+            and "/users/" in path
+            and "/role-mappings/clients/" in path
+        ):
+            state.setdefault("sa_role_bindings", []).extend(body)
+            return None
+        # GET /<realm>/group-by-path/<path>
+        if method == "GET" and path.startswith(f"/{REALM}/group-by-path/"):
+            requested = path.rsplit("/", 1)[1]
+            for g in state["groups"]:
+                if g["path"].lstrip("/") == requested:
+                    return {"id": g["id"], "path": g["path"]}
+            raise http_404()
+        # GET /<realm>/groups/<gid>/role-mappings/clients/<cuuid>
+        if (
+            method == "GET"
+            and "/groups/" in path
+            and "/role-mappings/clients/" in path
+        ):
+            gid = path.split("/")[3]
+            return list(state.get("group_role_bindings", {}).get(gid, []))
+        # POST role assignment to group
+        if (
+            method == "POST"
+            and "/groups/" in path
+            and "/role-mappings/clients/" in path
+        ):
+            gid = path.split("/")[3]
+            state.setdefault("group_role_bindings", {}).setdefault(gid, []).extend(body)
+            return None
+        raise AssertionError(f"unexpected KC call: {method} {path}")
+
+    return respond
+
+
+def fresh_state():
+    """In-memory realm representing a freshly-created Keycloak: ``groups``
+    client-scope present (KC ships it by default) but no mapper yet, hub
+    client exists without serviceAccountsEnabled, no client roles, no
+    bindings, /admin group present."""
+    return {
+        "client_scopes": [{"id": "scope-groups", "name": "groups"}],
+        "mappers": {},
+        "clients": [
+            {
+                "id": HUB_UUID,
+                "clientId": HUB_CLIENT_ID,
+                "serviceAccountsEnabled": False,
+            },
+            {
+                "id": RM_UUID,
+                "clientId": "realm-management",
+                "serviceAccountsEnabled": True,
+            },
+        ],
+        "service_account_user": None,
+        "client_roles": {
+            RM_UUID: {
+                name: {"id": f"rm-role-{i}", "name": name}
+                for i, name in enumerate(rbac.REALM_MGMT_ROLES)
+            },
+        },
+        "sa_role_bindings": [],
+        "groups": [{"id": ADMIN_GROUP_ID, "path": ADMIN_GROUP_PATH}],
+        "group_role_bindings": {},
+    }
+
+
+def make_config(groups=("/admin",)):
+    return rbac.BootstrapConfig(
+        kc_host="http://kc.test",
+        admin_password="p",
+        realm=REALM,
+        hub_client_id=HUB_CLIENT_ID,
+        role_name=ROLE_NAME,
+        shared_mount_groups=tuple(groups),
+    )
+
+
+# Helper: drive enabling SA + creating SA user so subsequent steps work
+# the way KC actually behaves (SA user appears after the toggle flips).
+def enable_sa_then_appear(state):
+    """KC's actual behaviour: after PUT enables serviceAccountsEnabled,
+    the SA user is created. Simulate it by patching `state` once the
+    PUT fires."""
+    state["service_account_user"] = {"id": SA_USER_ID, "username": "sa"}
+
+
+# ---------------------------------------------------------------------------
+# run() against a fresh realm — exercises the full pipeline
+# ---------------------------------------------------------------------------
+
+def test_run_on_fresh_realm_creates_mapper_role_and_assignment():
+    state = fresh_state()
+
+    def respond(method, path, **kw):
+        if method == "PUT" and path == f"/{REALM}/clients/{HUB_UUID}":
+            enable_sa_then_appear(state)
+        return _fake_realm(state)(method, path, **kw)
+
+    kc = make_kc(respond)
+    rbac.run(make_config(), kc)
+
+    # Mapper is in place.
+    assert any(
+        m["name"] == "group-membership"
+        for m in state["mappers"]["scope-groups"]
+    ), "groups scope must have a group-membership mapper"
+
+    # serviceAccountsEnabled flipped.
+    hub = next(c for c in state["clients"] if c["id"] == HUB_UUID)
+    assert hub["serviceAccountsEnabled"] is True
+
+    # All required realm-management roles bound to the SA.
+    bound = {b["name"] for b in state["sa_role_bindings"]}
+    assert set(rbac.REALM_MGMT_ROLES).issubset(bound), (
+        f"expected SA to hold {rbac.REALM_MGMT_ROLES}, got {bound}"
+    )
+
+    # The shared-directory role exists on hub client with the required attrs.
+    role = state["client_roles"][HUB_UUID][ROLE_NAME]
+    assert role["attributes"] == rbac.SHARED_DIR_ATTRIBUTES
+
+    # /admin group got the role assigned.
+    assigned = [
+        b["name"]
+        for b in state["group_role_bindings"].get(ADMIN_GROUP_ID, [])
+    ]
+    assert ROLE_NAME in assigned
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — second run is a no-op (no POST/PUT/DELETE state changes)
+# ---------------------------------------------------------------------------
+
+def test_run_twice_is_a_noop_on_second_pass():
+    """The Helm Job runs on every install AND every upgrade. The second
+    invocation MUST NOT mutate realm state — otherwise upgrade rolls
+    produce noise in KC audit logs and the deployment becomes flaky."""
+    state = fresh_state()
+
+    def respond(method, path, **kw):
+        if method == "PUT" and path == f"/{REALM}/clients/{HUB_UUID}":
+            enable_sa_then_appear(state)
+        return _fake_realm(state)(method, path, **kw)
+
+    kc1 = make_kc(respond)
+    rbac.run(make_config(), kc1)
+
+    # Capture every call the second run makes.
+    kc2 = make_kc(respond)
+    rbac.run(make_config(), kc2)
+    second_pass_calls = kc2._request.call_args_list
+
+    mutating = [
+        call for call in second_pass_calls
+        if call.args[0] in ("POST", "PUT", "DELETE")
+    ]
+    assert mutating == [], (
+        f"second run must be read-only; got mutating calls: "
+        f"{[c.args[:2] for c in mutating]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Missing groups in the deployer's list don't crash the bootstrap
+# ---------------------------------------------------------------------------
+
+def test_unknown_group_path_is_skipped_with_a_warning(caplog):
+    """Deployer typos a group name in ``sharedMountGroups``. The bootstrap
+    must continue with the rest (real groups get the role, hub still
+    works) rather than aborting and leaving the realm half-configured."""
+    state = fresh_state()
+
+    def respond(method, path, **kw):
+        if method == "PUT" and path == f"/{REALM}/clients/{HUB_UUID}":
+            enable_sa_then_appear(state)
+        return _fake_realm(state)(method, path, **kw)
+
+    kc = make_kc(respond)
+    cfg = make_config(groups=("/admin", "/no-such-group"))
+    with caplog.at_level("WARNING", logger="rbac-bootstrap"):
+        rbac.run(cfg, kc)
+
+    assert any(
+        "no-such-group" in record.message
+        for record in caplog.records
+    ), "missing group path should produce a WARNING"
+    # /admin still got the role.
+    assert ROLE_NAME in [
+        b["name"]
+        for b in state["group_role_bindings"][ADMIN_GROUP_ID]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Role with stale attributes is reconciled
+# ---------------------------------------------------------------------------
+
+def test_existing_role_with_wrong_attributes_is_reconciled():
+    """Deployer (or an older bootstrap) left the role around with the
+    wrong attribute pair. The script must PUT to fix it, not leave the
+    realm in a broken state where the hub's KCRealmAdmin filter sees
+    'no required attrs' and silently returns []."""
+    state = fresh_state()
+    state["client_roles"][HUB_UUID] = {
+        ROLE_NAME: {
+            "id": ROLE_ID,
+            "name": ROLE_NAME,
+            "attributes": {"component": ["wrong-component"]},
+        },
+    }
+
+    def respond(method, path, **kw):
+        if method == "PUT" and path == f"/{REALM}/clients/{HUB_UUID}":
+            enable_sa_then_appear(state)
+        return _fake_realm(state)(method, path, **kw)
+
+    kc = make_kc(respond)
+    rbac.run(make_config(), kc)
+
+    role = state["client_roles"][HUB_UUID][ROLE_NAME]
+    assert role["attributes"] == rbac.SHARED_DIR_ATTRIBUTES

--- a/values.yaml
+++ b/values.yaml
@@ -217,8 +217,13 @@ rbac:
     #   - /admin
     #   - /developer
     sharedMountGroups: []
-    # Image used to run kcadm.sh (matches the realm's Keycloak version).
-    image: "quay.io/keycloak/keycloak:24.0.5"
+    # Keycloak server URL the bootstrap script talks to (Admin REST API
+    # lives at ``<kcHost>/admin/realms/...``). In-cluster service URL by
+    # default; override if Keycloak sits at a different hostname.
+    kcHost: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080"
+    # Image that runs ``files/keycloak_rbac_bootstrap.py``. The script
+    # uses only the standard library, so any small Python image works.
+    image: "python:3.12-slim"
 
 # JupyterHub configuration
 # All values under this key are passed to the jupyterhub subchart


### PR DESCRIPTION
The previous `templates/keycloak-rbac-bootstrap-job.yaml` embedded ~120 lines of bash that talked to Keycloak via `kcadm.sh` and parsed JSON with `grep` + `sed`. Untestable, brittle (the live `/admin` lookup bug from #62 review came from sed-anchoring a path against an arbitrary JSON field order), and noisy (`|| echo "may already exist"` swallowed real errors).

This PR ships:

* `files/keycloak_rbac_bootstrap.py` — plain Python (stdlib only, no pip). `KCAdmin` class with one small method per KC Admin endpoint; `run()` orchestrator with explicit idempotency per step.
* `tests/unit/test_keycloak_rbac_bootstrap.py` — 7 unit tests driving the public contract through an in-memory KC fake: full pipeline on a fresh realm, second-run is a strict no-op, unknown group paths skip with a WARNING, role attributes are reconciled on drift, env-var parsing rejects missing required vars.
* `templates/keycloak-rbac-bootstrap-job.yaml` — slim YAML: ConfigMap ships the script via `.Files.Get`; Job mounts it and runs `python /scripts/keycloak_rbac_bootstrap.py`. `checksum/script` annotation forces a re-roll on script changes.
* `values.yaml` — default image flips from `quay.io/keycloak/keycloak:24.0.5` to `python:3.12-slim`; new `rbac.bootstrap.kcHost` field replaces a hard-coded constant.

44/44 unit tests green (37 existing + 7 new).