### PR TITLE
feat(ci): auto-bump values.yaml image tags after build-images on main

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -1,0 +1,62 @@
+# Auto-bump image tags in values.yaml after build-images.yaml succeeds on main.
+#
+# Triggers when Build Docker Images completes on main, computes the
+# sha-<short> tag from the head SHA, runs scripts/bump_image_tags.py to
+# update jupyterhub.hub.image.tag and jupyterhub.singleuser.image.tag in
+# values.yaml, then commits + pushes directly to main with [skip ci] in
+# the message so the bump commit does not retrigger the workflow chain.
+name: "Bump Image Tags"
+
+on:
+  workflow_run:
+    workflows: ["Build Docker Images"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bump-image-tags
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: "Bump values.yaml"
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: "Install ruamel.yaml"
+        run: pip install --no-cache-dir "ruamel.yaml==0.19.1"
+
+      - name: "Compute short SHA"
+        id: sha
+        run: |
+          short=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          echo "short=$short" >> "$GITHUB_OUTPUT"
+
+      - name: "Bump tags in values.yaml"
+        run: python scripts/bump_image_tags.py "${{ steps.sha.outputs.short }}"
+
+      - name: "Commit and push if changed"
+        env:
+          SHORT: ${{ steps.sha.outputs.short }}
+        run: |
+          if git diff --quiet -- values.yaml; then
+            echo "values.yaml already at sha-$SHORT — nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add values.yaml
+          git commit -m "chore: bump image tags to sha-$SHORT [skip ci]"
+          git push origin main

--- a/scripts/bump_image_tags.py
+++ b/scripts/bump_image_tags.py
@@ -1,0 +1,68 @@
+"""Bump image tags in values.yaml after a build-images workflow run.
+
+Updates `jupyterhub.hub.image.tag` and `jupyterhub.singleuser.image.tag` to
+`sha-<short>`. Uses ruamel.yaml round-trip mode to preserve comments and
+formatting in the file.
+
+Usage:
+    python scripts/bump_image_tags.py <short-sha> [path/to/values.yaml]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_VALUES = REPO_ROOT / "values.yaml"
+
+TARGETS = (
+    ("jupyterhub", "hub", "image", "tag"),
+    ("jupyterhub", "singleuser", "image", "tag"),
+)
+
+
+def bump(values_path: Path, short_sha: str) -> bool:
+    """Set both target tags to ``sha-<short_sha>``. Returns True if file changed."""
+    if not short_sha or any(c.isspace() for c in short_sha):
+        raise ValueError(f"refusing to write empty/whitespace sha: {short_sha!r}")
+
+    new_tag = f"sha-{short_sha}"
+
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    yaml.width = 4096  # don't reflow long lines
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    data = yaml.load(values_path)
+
+    changed = False
+    for keys in TARGETS:
+        node = data
+        for k in keys[:-1]:
+            node = node[k]
+        leaf = keys[-1]
+        if node[leaf] != new_tag:
+            node[leaf] = new_tag
+            changed = True
+
+    if changed:
+        yaml.dump(data, values_path)
+    return changed
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2 or len(argv) > 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    short_sha = argv[1]
+    values_path = Path(argv[2]) if len(argv) == 3 else DEFAULT_VALUES
+    changed = bump(values_path, short_sha)
+    print(f"{'updated' if changed else 'unchanged'}: {values_path} -> sha-{short_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
Closes #68.

## What

Adds a workflow that, after **Build Docker Images** succeeds on `main`, rewrites the two `sha-<short>` image tags in `values.yaml` and commits the bump directly to `main`.

Updated tags:
- `jupyterhub.hub.image.tag` — `nebari-data-science-pack-jupyterhub`
- `jupyterhub.singleuser.image.tag` — `nebari-data-science-pack-jupyterlab`

`jupyterlab-base` / `jupyterlab-gpu*` are not currently referenced in `values.yaml`, so they are out of scope.

## How

- `.github/workflows/bump-image-tags.yaml` — `workflow_run` trigger gated on `head_branch == 'main'` and `conclusion == 'success'`, computes `sha-<7-char>` from `workflow_run.head_sha`, runs the script, then commits + pushes to `main` with `[skip ci]` so the bump commit does not retrigger the workflow chain.
- `scripts/bump_image_tags.py` — small Python script using `ruamel.yaml` round-trip mode. Verified locally that the resulting diff against `values.yaml` is exactly the two intended lines, with no incidental formatting churn.

## Verification

```
$ python scripts/bump_image_tags.py abcd123 values.yaml
$ git diff values.yaml
@@ values.yaml @@
-      tag: "sha-67880ee"
+      tag: "sha-abcd123"
...
-      tag: "sha-8f2e545"
+      tag: "sha-abcd123"
```

Two lines change, nothing else.

## Notes

- `concurrency: bump-image-tags` (no cancel-in-progress) so two builds finishing close together queue rather than racing on the push.
- Uses the default `GITHUB_TOKEN` with `permissions: contents: write`. If branch protection on `main` blocks the push, a PAT or a GitHub App token will be needed.
- Pinned: `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`, `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0`, `ruamel.yaml==0.19.1`.