### PR TITLE
feat(spawner): expose PREFERRED_USERNAME for terminal prompt

### DIFF
--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -781,6 +781,13 @@ async def _pre_spawn_hook(spawner):
     else:
         log.debug("pre-spawn: auth_state keys for %s: %s", username, list(auth_state.keys()))
 
+    # Expose PREFERRED_USERNAME for the singleuser pod (matches classic
+    # nebari's 02-spawner.get_username_hook). The terminal prompt and any
+    # downstream tooling read this env var.
+    oauth_user = (auth_state or {}).get("oauth_user") or {}
+    preferred_username = oauth_user.get("preferred_username") or username
+    spawner.environment = {**spawner.environment, "PREFERRED_USERNAME": preferred_username}
+
     # 1. Nebi auto-auth (non-fatal)
     if _nebi_auth_configured:
         log.debug("pre-spawn: running Nebi auto-auth for %s", username)

--- a/images/terminal/nebari-terminal.sh
+++ b/images/terminal/nebari-terminal.sh
@@ -20,6 +20,12 @@ alias l='ls -lah'
 alias ll='ls -lah'
 alias la='ls -A'
 
+# PREFERRED_USERNAME is set by the KubeSpawner pre_spawn_hook (see
+# config/jupyterhub/01-spawner.py, matching classic nebari's
+# get_username_hook) from the OIDC preferred_username claim. The
+# starship prompt reads it via env_var. We keep it as-is — never strip
+# the @domain, since users from different orgs may share a local-part.
+
 # Use the system starship.toml unless the user explicitly overrides.
 if [ -z "${STARSHIP_CONFIG}" ]; then
     export STARSHIP_CONFIG="/etc/starship.toml"

--- a/images/terminal/starship.toml
+++ b/images/terminal/starship.toml
@@ -8,13 +8,15 @@
 add_newline = false
 
 format = """
-$username$env_var$git_branch$git_status$python$conda$cmd_duration$line_break$character"""
+$env_var$git_branch$git_status$python$conda$cmd_duration$line_break$character"""
 
-[username]
-show_always = true
-style_user = "bold fg:#0d6efd"
-style_root = "bold fg:#dc2626"
-format = '[$user]($style) '
+# Username — set by the KubeSpawner pre_spawn_hook from the OIDC
+# preferred_username claim (mirrors classic nebari's get_username_hook).
+# Avoids starship's [username] module, which reads $USER (empty in
+# z2jh pods) and falls back to getpwuid → "jovyan".
+[env_var.PREFERRED_USERNAME]
+style = "bold fg:#0d6efd"
+format = '[$env_value]($style) '
 
 # Use the shell's $PWD instead of starship's [directory] module so the
 # prompt shows the full path (e.g. /home/jovyan) instead of the
@@ -53,6 +55,8 @@ success_symbol = '[❯](bold fg:#16a34a)'
 error_symbol = '[❯](bold fg:#dc2626)'
 
 # Disable noisy or duplicate modules
+[username]
+disabled = true
 [directory]
 disabled = true
 [os]


### PR DESCRIPTION
## Summary
- Add a pre-spawn step that reads `auth_state['oauth_user']['preferred_username']` and injects it as `PREFERRED_USERNAME` on the singleuser pod (mirrors classic nebari's `02-spawner.get_username_hook`).
- The starship prompt now reads `$PREFERRED_USERNAME` instead of `$USER` (which z2jh leaves unset, so starship falls through to `getpwuid` → `jovyan`).
- Username is shown verbatim — the `@domain` is never stripped, since users from different orgs may share a local-part.

## Test plan
- [ ] After this lands, respawn a singleuser pod and check `env | grep PREFERRED_USERNAME` matches the OIDC `preferred_username` claim.
- [ ] Open a new JupyterLab terminal and confirm the prompt shows the full user identifier (not `jovyan`).