### PR TITLE
fix(ci): use BOT_PAT for bump push + allow workflow_dispatch

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -12,6 +12,11 @@ on:
     workflows: ["Build Docker Images"]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Full commit SHA whose images have been built/pushed"
+        required: true
 
 permissions:
   contents: write
@@ -23,7 +28,7 @@ concurrency:
 jobs:
   bump:
     name: "Bump values.yaml"
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,7 +50,12 @@ jobs:
       - name: "Compute short SHA"
         id: sha
         run: |
-          short=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            full="${{ inputs.sha }}"
+          else
+            full="${{ github.event.workflow_run.head_sha }}"
+          fi
+          short=$(echo "$full" | cut -c1-7)
           echo "short=$short" >> "$GITHUB_OUTPUT"
 
       - name: "Bump tags in values.yaml"

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -30,6 +30,10 @@ jobs:
         with:
           ref: main
           fetch-depth: 1
+          # PAT (Contents:Write) belonging to a bypass actor on the main
+          # ruleset; required because GITHUB_TOKEN cannot bypass the
+          # "Changes must be made through a pull request" rule.
+          token: ${{ secrets.BOT_PAT }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
Follow-up to #69.

## Why

PR #69 merged but the **Bump Image Tags** run failed at the push step:

> `remote: error: GH013: Repository rule violations found for refs/heads/main.`
> `remote: Changes must be made through a pull request.`

`GITHUB_TOKEN` cannot bypass the main ruleset, and the github-actions integration is not a selectable bypass actor at the repo level (UI only offers roles, teams, deploy keys).

## What

1. **Switch checkout to use `BOT_PAT`** — a fine-grained PAT (Contents: Write) belonging to a user on the ruleset bypass list. `git push` from the workflow now goes through.
2. **Add `workflow_dispatch`** with a **required** `sha` input — lets us manually re-run the bump for a specific commit (e.g. for the `af142e0` build that already shipped but never got the auto-bump).

## Setup (must be done before merge)

1. On https://github.com/nebari-dev/nebari-data-science-pack/settings/rules/15783862 — add **Repository admin** (or **Maintain**) to the Bypass list, mode **Always**.
2. Create a fine-grained PAT for `nebari-data-science-pack` with **Contents: Read and write**.
3. `gh secret set BOT_PAT --repo nebari-dev/nebari-data-science-pack < /tmp/bot_pat`

After merge, run **Bump Image Tags** manually with `sha=af142e0` (or any newer head) to back-fill.