### PR TITLE
chore: bump image tags to sha-60c3d6f

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -292,7 +292,7 @@ jupyterhub:
     # class clears current_user — id_token_hint now reaches KC).
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterhub
-      tag: "sha-67880ee"
+      tag: "sha-60c3d6f"
 
     config:
       JupyterHub:
@@ -350,7 +350,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterlab
-      tag: "sha-8f2e545"
+      tag: "sha-60c3d6f"
     defaultUrl: "/lab"
     extraEnv:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"


### PR DESCRIPTION
Manual bump: hub + singleuser image tags → `sha-60c3d6f` (head of main, built by [run 25952846516](https://github.com/nebari-dev/nebari-data-science-pack/actions/runs/25952846516)).

Doing this by hand because the auto-bump workflow is currently blocked on PAT/repo-write permission for `nebari-sensei` (see failed runs on #69 / #71). Once that's resolved, future bumps will land automatically.