### PR TITLE
chore: release 0.1.0-alpha.12

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nebari-data-science-pack
 description: A Helm chart for deploying JupyterHub with jhub-apps on Kubernetes
 type: application
-version: 0.1.0-alpha.11
+version: 0.1.0-alpha.12
 appVersion: "1.0.0"
 
 dependencies:


### PR DESCRIPTION
Bumps Chart.yaml version to 0.1.0-alpha.12. Merging triggers the Release Chart workflow which publishes the chart to the gh-pages index.