### PR TITLE
feat(jupyterlab): default fonts to IBM Plex Sans / Fira Code

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -149,16 +149,18 @@ RUN sed -i 's#</head>#<link rel="stylesheet" href="{{ base_url | escape }}static
 
 # ========== IBM Plex Sans (default UI + content font) ===========
 # Install woff2 files + @font-face CSS, then point JupyterLab's themes
-# at the family via overrides.json (the schema-blessed path —
-# @jupyterlab/apputils-extension:themes / ui-font-family /
-# content-font-family).
+# at the family via user-settings. NOTE: app-settings/overrides.json
+# does NOT work for theme overrides — apputils-extension reads
+# `settings.user.overrides` (not `composite.overrides`), so the admin
+# override path is bypassed. User-settings is the path that actually
+# applies these CSS variables.
 RUN PATH="/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${PATH}" \
     /opt/scripts/install-ibm-plex-sans.sh "${JLAB_STATIC}"
 COPY terminal/ibm-plex-sans.css ${JLAB_STATIC}/fonts/ibm-plex-sans.css
 RUN sed -i 's#</head>#<link rel="stylesheet" href="{{ base_url | escape }}static/lab/fonts/ibm-plex-sans.css"></head>#' \
     "${JLAB_STATIC}/index.html"
-RUN mkdir -p /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings
-COPY jupyterlab/overrides.json /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings/overrides.json
+RUN mkdir -p /etc/skel/.jupyter/lab/user-settings/@jupyterlab/apputils-extension
+COPY terminal/themes-settings.json /etc/skel/.jupyter/lab/user-settings/@jupyterlab/apputils-extension/themes.jupyterlab-settings
 
 COPY terminal/bashrc /etc/skel/.bashrc
 COPY terminal/nebari-terminal.sh /etc/profile.d/nebari-terminal.sh

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -147,6 +147,19 @@ COPY terminal/firacode.css ${JLAB_STATIC}/fonts/firacode.css
 RUN sed -i 's|</head>|<link rel="stylesheet" href="/static/lab/fonts/firacode.css"></head>|' \
     "${JLAB_STATIC}/index.html"
 
+# ========== IBM Plex Sans (default UI + content font) ===========
+# Install woff2 files + @font-face CSS, then point JupyterLab's themes
+# at the family via overrides.json (the schema-blessed path —
+# @jupyterlab/apputils-extension:themes / ui-font-family /
+# content-font-family).
+RUN PATH="/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${PATH}" \
+    /opt/scripts/install-ibm-plex-sans.sh "${JLAB_STATIC}"
+COPY terminal/ibm-plex-sans.css ${JLAB_STATIC}/fonts/ibm-plex-sans.css
+RUN sed -i 's|</head>|<link rel="stylesheet" href="/static/lab/fonts/ibm-plex-sans.css"></head>|' \
+    "${JLAB_STATIC}/index.html"
+RUN mkdir -p /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings
+COPY jupyterlab/overrides.json /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings/overrides.json
+
 COPY terminal/bashrc /etc/skel/.bashrc
 COPY terminal/nebari-terminal.sh /etc/profile.d/nebari-terminal.sh
 COPY terminal/starship.toml /etc/starship.toml

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -144,7 +144,7 @@ RUN PATH="/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${PATH}" \
 # Wire the @font-face declarations into the page so xterm.js can use the
 # font. Drop the CSS next to the WOFF2 files and add one <link> to index.html.
 COPY terminal/firacode.css ${JLAB_STATIC}/fonts/firacode.css
-RUN sed -i 's|</head>|<link rel="stylesheet" href="/static/lab/fonts/firacode.css"></head>|' \
+RUN sed -i 's|</head>|<link rel="stylesheet" href="{{ base_url | escape }}static/lab/fonts/firacode.css"></head>|' \
     "${JLAB_STATIC}/index.html"
 
 # ========== IBM Plex Sans (default UI + content font) ===========
@@ -155,7 +155,7 @@ RUN sed -i 's|</head>|<link rel="stylesheet" href="/static/lab/fonts/firacode.cs
 RUN PATH="/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${PATH}" \
     /opt/scripts/install-ibm-plex-sans.sh "${JLAB_STATIC}"
 COPY terminal/ibm-plex-sans.css ${JLAB_STATIC}/fonts/ibm-plex-sans.css
-RUN sed -i 's|</head>|<link rel="stylesheet" href="/static/lab/fonts/ibm-plex-sans.css"></head>|' \
+RUN sed -i 's|</head>|<link rel="stylesheet" href="{{ base_url | escape }}static/lab/fonts/ibm-plex-sans.css"></head>|' \
     "${JLAB_STATIC}/index.html"
 RUN mkdir -p /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings
 COPY jupyterlab/overrides.json /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings/overrides.json

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -144,7 +144,7 @@ RUN PATH="/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${PATH}" \
 # Wire the @font-face declarations into the page so xterm.js can use the
 # font. Drop the CSS next to the WOFF2 files and add one <link> to index.html.
 COPY terminal/firacode.css ${JLAB_STATIC}/fonts/firacode.css
-RUN sed -i 's|</head>|<link rel="stylesheet" href="{{ base_url | escape }}static/lab/fonts/firacode.css"></head>|' \
+RUN sed -i 's#</head>#<link rel="stylesheet" href="{{ base_url | escape }}static/lab/fonts/firacode.css"></head>#' \
     "${JLAB_STATIC}/index.html"
 
 # ========== IBM Plex Sans (default UI + content font) ===========
@@ -155,7 +155,7 @@ RUN sed -i 's|</head>|<link rel="stylesheet" href="{{ base_url | escape }}static
 RUN PATH="/opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/bin:${PATH}" \
     /opt/scripts/install-ibm-plex-sans.sh "${JLAB_STATIC}"
 COPY terminal/ibm-plex-sans.css ${JLAB_STATIC}/fonts/ibm-plex-sans.css
-RUN sed -i 's|</head>|<link rel="stylesheet" href="{{ base_url | escape }}static/lab/fonts/ibm-plex-sans.css"></head>|' \
+RUN sed -i 's#</head>#<link rel="stylesheet" href="{{ base_url | escape }}static/lab/fonts/ibm-plex-sans.css"></head>#' \
     "${JLAB_STATIC}/index.html"
 RUN mkdir -p /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings
 COPY jupyterlab/overrides.json /opt/jupyterlab/.pixi/envs/${DEFAULT_ENV}/share/jupyter/lab/settings/overrides.json

--- a/images/jupyterlab/overrides.json
+++ b/images/jupyterlab/overrides.json
@@ -1,9 +1,0 @@
-{
-  "@jupyterlab/apputils-extension:themes": {
-    "overrides": {
-      "ui-font-family": "'IBM Plex Sans', system-ui, -apple-system, sans-serif",
-      "content-font-family": "'IBM Plex Sans', system-ui, -apple-system, sans-serif",
-      "code-font-family": "'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-    }
-  }
-}

--- a/images/jupyterlab/overrides.json
+++ b/images/jupyterlab/overrides.json
@@ -1,0 +1,9 @@
+{
+  "@jupyterlab/apputils-extension:themes": {
+    "overrides": {
+      "ui-font-family": "'IBM Plex Sans', system-ui, -apple-system, sans-serif",
+      "content-font-family": "'IBM Plex Sans', system-ui, -apple-system, sans-serif",
+      "code-font-family": "'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+    }
+  }
+}

--- a/images/nebi/jupyter_server_config.py
+++ b/images/nebi/jupyter_server_config.py
@@ -1,9 +1,22 @@
 import mimetypes
 import os
+import shutil
+from pathlib import Path
 
 # Browser rejects woff2 with "Failed to decode" if the server returns
 # application/octet-stream. Register the correct MIME type.
 mimetypes.add_type("font/woff2", ".woff2")
+
+# Seed apputils-extension theme settings (IBM Plex Sans + Fira Code) into the
+# user's home on every spawn. We *must* use user-settings, not admin-level
+# overrides.json — `@jupyterlab/apputils-extension:themes` reads
+# `settings.user.overrides` (NOT composite), so the schema-default path is
+# bypassed. Only seed when no file exists, so user-customized themes win.
+_skel = Path("/etc/skel/.jupyter/lab/user-settings/@jupyterlab/apputils-extension/themes.jupyterlab-settings")
+_dest = Path(os.environ.get("HOME", "")) / ".jupyter/lab/user-settings/@jupyterlab/apputils-extension/themes.jupyterlab-settings"
+if _skel.exists() and not _dest.exists():
+    _dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(_skel, _dest)
 
 # jupyter-server-proxy configuration for Nebi
 # Launches `nebi serve` when the user clicks "Nebi" in the JupyterLab launcher.

--- a/images/scripts/install-ibm-plex-sans.sh
+++ b/images/scripts/install-ibm-plex-sans.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Install IBM Plex Sans woff2 files for JupyterLab UI/content font.
+# Four faces: Regular, Bold, Italic, BoldItalic.
+set -euo pipefail
+
+PLEX_VERSION="${PLEX_VERSION:-1.1.0}"
+JUPYTERLAB_STATIC_DIR="${1:?Usage: install-ibm-plex-sans.sh <jupyterlab-static-dir>}"
+FONT_DIR="${JUPYTERLAB_STATIC_DIR}/fonts"
+
+mkdir -p "${FONT_DIR}"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+curl -fsSL -o "${TMP_DIR}/ibm-plex-sans.zip" \
+    "https://github.com/IBM/plex/releases/download/%40ibm/plex-sans%40${PLEX_VERSION}/ibm-plex-sans.zip"
+
+unzip -q -j "${TMP_DIR}/ibm-plex-sans.zip" \
+    'ibm-plex-sans/fonts/complete/woff2/IBMPlexSans-Regular.woff2' \
+    'ibm-plex-sans/fonts/complete/woff2/IBMPlexSans-Bold.woff2' \
+    'ibm-plex-sans/fonts/complete/woff2/IBMPlexSans-Italic.woff2' \
+    'ibm-plex-sans/fonts/complete/woff2/IBMPlexSans-BoldItalic.woff2' \
+    -d "${FONT_DIR}"
+
+echo "IBM Plex Sans installed to ${FONT_DIR}"

--- a/images/terminal/firacode.css
+++ b/images/terminal/firacode.css
@@ -3,12 +3,12 @@
   font-style: normal;
   font-weight: 400;
   font-display: block;
-  src: url('/static/lab/fonts/FiraCode-Regular.woff2') format('woff2');
+  src: url('FiraCode-Regular.woff2') format('woff2');
 }
 @font-face {
   font-family: 'Fira Code';
   font-style: normal;
   font-weight: 700;
   font-display: block;
-  src: url('/static/lab/fonts/FiraCode-Bold.woff2') format('woff2');
+  src: url('FiraCode-Bold.woff2') format('woff2');
 }

--- a/images/terminal/ibm-plex-sans.css
+++ b/images/terminal/ibm-plex-sans.css
@@ -1,0 +1,28 @@
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url('/static/lab/fonts/IBMPlexSans-Regular.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: block;
+  src: url('/static/lab/fonts/IBMPlexSans-Bold.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  font-display: block;
+  src: url('/static/lab/fonts/IBMPlexSans-Italic.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 700;
+  font-display: block;
+  src: url('/static/lab/fonts/IBMPlexSans-BoldItalic.woff2') format('woff2');
+}

--- a/images/terminal/ibm-plex-sans.css
+++ b/images/terminal/ibm-plex-sans.css
@@ -3,26 +3,26 @@
   font-style: normal;
   font-weight: 400;
   font-display: block;
-  src: url('/static/lab/fonts/IBMPlexSans-Regular.woff2') format('woff2');
+  src: url('IBMPlexSans-Regular.woff2') format('woff2');
 }
 @font-face {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   font-weight: 700;
   font-display: block;
-  src: url('/static/lab/fonts/IBMPlexSans-Bold.woff2') format('woff2');
+  src: url('IBMPlexSans-Bold.woff2') format('woff2');
 }
 @font-face {
   font-family: 'IBM Plex Sans';
   font-style: italic;
   font-weight: 400;
   font-display: block;
-  src: url('/static/lab/fonts/IBMPlexSans-Italic.woff2') format('woff2');
+  src: url('IBMPlexSans-Italic.woff2') format('woff2');
 }
 @font-face {
   font-family: 'IBM Plex Sans';
   font-style: italic;
   font-weight: 700;
   font-display: block;
-  src: url('/static/lab/fonts/IBMPlexSans-BoldItalic.woff2') format('woff2');
+  src: url('IBMPlexSans-BoldItalic.woff2') format('woff2');
 }

--- a/images/terminal/themes-settings.json
+++ b/images/terminal/themes-settings.json
@@ -1,0 +1,7 @@
+{
+    "overrides": {
+        "ui-font-family": "'IBM Plex Sans', system-ui, -apple-system, sans-serif",
+        "content-font-family": "'IBM Plex Sans', system-ui, -apple-system, sans-serif",
+        "code-font-family": "'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+    }
+}

--- a/values.yaml
+++ b/values.yaml
@@ -290,10 +290,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-969f595"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-499f3ce"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-969f595
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-499f3ce
       - slug: medium-instance
         display_name: "Medium Instance"
         description: "4 CPU / 8 GB RAM — pandas / scikit-learn workloads on medium datasets."
@@ -307,10 +307,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-969f595"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-499f3ce"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-969f595
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-499f3ce
     # Terminal customization: controls Starship prompt in JupyterLab terminals.
     # When false, falls back to the default bash prompt.
     terminal-customization: true
@@ -359,7 +359,7 @@ jupyterhub:
     # class clears current_user — id_token_hint now reaches KC).
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterhub
-      tag: "sha-969f595"
+      tag: "sha-499f3ce"
 
     config:
       JupyterHub:
@@ -449,7 +449,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterlab
-      tag: "sha-969f595"
+      tag: "sha-499f3ce"
     defaultUrl: "/lab"
     extraEnv:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"

--- a/values.yaml
+++ b/values.yaml
@@ -290,10 +290,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-60c3d6f"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-9f2f2e5"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-60c3d6f
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-9f2f2e5
       - slug: medium-instance
         display_name: "Medium Instance"
         description: "4 CPU / 8 GB RAM — pandas / scikit-learn workloads on medium datasets."
@@ -307,10 +307,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-60c3d6f"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-9f2f2e5"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-60c3d6f
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-9f2f2e5
     # Terminal customization: controls Starship prompt in JupyterLab terminals.
     # When false, falls back to the default bash prompt.
     terminal-customization: true

--- a/values.yaml
+++ b/values.yaml
@@ -359,7 +359,7 @@ jupyterhub:
     # class clears current_user — id_token_hint now reaches KC).
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterhub
-      tag: "sha-60c3d6f"
+      tag: "sha-9f2f2e5"
 
     config:
       JupyterHub:
@@ -449,7 +449,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterlab
-      tag: "sha-60c3d6f"
+      tag: "sha-9f2f2e5"
     defaultUrl: "/lab"
     extraEnv:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"

--- a/values.yaml
+++ b/values.yaml
@@ -290,10 +290,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-9f2f2e5"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-969f595"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-9f2f2e5
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-969f595
       - slug: medium-instance
         display_name: "Medium Instance"
         description: "4 CPU / 8 GB RAM — pandas / scikit-learn workloads on medium datasets."
@@ -307,10 +307,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-9f2f2e5"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-969f595"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-9f2f2e5
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-969f595
     # Terminal customization: controls Starship prompt in JupyterLab terminals.
     # When false, falls back to the default bash prompt.
     terminal-customization: true
@@ -359,7 +359,7 @@ jupyterhub:
     # class clears current_user — id_token_hint now reaches KC).
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterhub
-      tag: "sha-9f2f2e5"
+      tag: "sha-969f595"
 
     config:
       JupyterHub:
@@ -449,7 +449,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterlab
-      tag: "sha-9f2f2e5"
+      tag: "sha-969f595"
     defaultUrl: "/lab"
     extraEnv:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"


### PR DESCRIPTION
## Summary
- Bake IBM Plex Sans v1.1.0 (UI + notebook content) and Fira Code (code cells / editor) into the JupyterLab singleuser image as the default fonts.
- Uses the schema-blessed [`@jupyterlab/apputils-extension:themes` overrides](https://jupyterlab.readthedocs.io/en/4.2.x/user/interface_customization.html) (`ui-font-family`, `content-font-family`, `code-font-family`) via `overrides.json` — no CSS-variable hacks.
- Fira Code is already loaded by the existing terminal customization block, so no extra font assets needed for code cells.

## Region → font

| Region | Source | Font |
|---|---|---|
| Sidebar, top menu, tab bar, dialogs, status bar, file browser, Launcher | `--jp-ui-font-family` | IBM Plex Sans |
| Notebook markdown cells, markdown preview | `--jp-content-font-family` | IBM Plex Sans |
| Code cells, code editor | `--jp-code-font-family` | Fira Code |
| Terminal (xterm.js) | `@jupyterlab/terminal-extension` user-settings (unchanged) | Fira Code |

## Files
- `images/scripts/install-ibm-plex-sans.sh` — downloads 4 woff2 faces from the [IBM/plex v1.1.0 release](https://github.com/IBM/plex/releases/tag/%40ibm/plex-sans%401.1.0) into `${JLAB_STATIC}/fonts/`.
- `images/terminal/ibm-plex-sans.css` — `@font-face` declarations for the 4 faces.
- `images/jupyterlab/overrides.json` — the `apputils-extension:themes` overrides, baked into `share/jupyter/lab/settings/overrides.json` in the env.
- `images/Dockerfile` — mirrors the FiraCode block: run install script, COPY css, sed `<link>` into `index.html`, then `mkdir -p` + COPY `overrides.json`.

## Test plan
- [ ] CI image build green on this branch.
- [ ] Pull the resulting image and confirm `share/jupyter/lab/settings/overrides.json` and `share/jupyter/lab/static/fonts/IBMPlexSans-Regular.woff2` exist.
- [ ] Launch a singleuser pod with the new tag and visually confirm:
  - Top menu / sidebar / launcher render in IBM Plex Sans.
  - A markdown cell renders in IBM Plex Sans.
  - A code cell renders in Fira Code.
  - Terminal still renders in Fira Code (unchanged).