### PR TITLE
feat(profiles): surface image picker in jhub-apps Create App

### DIFF
--- a/scripts/bump_image_tags.py
+++ b/scripts/bump_image_tags.py
@@ -1,8 +1,14 @@
 """Bump image tags in values.yaml after a build-images workflow run.
 
-Updates `jupyterhub.hub.image.tag` and `jupyterhub.singleuser.image.tag` to
-`sha-<short>`. Uses ruamel.yaml round-trip mode to preserve comments and
-formatting in the file.
+Updates every image reference in ``values.yaml`` to ``sha-<short>``:
+
+* ``jupyterhub.hub.image.tag`` (string)
+* ``jupyterhub.singleuser.image.tag`` (string)
+* Per-profile ``profile_list[*].kubespawner_override.image`` (full ref)
+* Per-profile ``profile_list[*].profile_options.image.choices.<key>.display_name``
+* Per-profile ``profile_list[*].profile_options.image.choices.<key>.kubespawner_override.image``
+
+Uses ruamel.yaml round-trip mode to preserve comments and formatting.
 
 Usage:
     python scripts/bump_image_tags.py <short-sha> [path/to/values.yaml]
@@ -18,28 +24,18 @@ from ruamel.yaml import YAML
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_VALUES = REPO_ROOT / "values.yaml"
 
-TARGETS = (
+TAG_TARGETS = (
     ("jupyterhub", "hub", "image", "tag"),
     ("jupyterhub", "singleuser", "image", "tag"),
 )
 
+JUPYTERLAB_IMAGE = "quay.io/nebari/nebari-data-science-pack-jupyterlab"
+JUPYTERLAB_DISPLAY_PREFIX = "nebari-data-science-pack-jupyterlab"
 
-def bump(values_path: Path, short_sha: str) -> bool:
-    """Set both target tags to ``sha-<short_sha>``. Returns True if file changed."""
-    if not short_sha or any(c.isspace() for c in short_sha):
-        raise ValueError(f"refusing to write empty/whitespace sha: {short_sha!r}")
 
-    new_tag = f"sha-{short_sha}"
-
-    yaml = YAML(typ="rt")
-    yaml.preserve_quotes = True
-    yaml.width = 4096  # don't reflow long lines
-    yaml.indent(mapping=2, sequence=4, offset=2)
-
-    data = yaml.load(values_path)
-
+def _bump_tag_leaves(data, new_tag: str) -> bool:
     changed = False
-    for keys in TARGETS:
+    for keys in TAG_TARGETS:
         node = data
         for k in keys[:-1]:
             node = node[k]
@@ -47,7 +43,56 @@ def bump(values_path: Path, short_sha: str) -> bool:
         if node[leaf] != new_tag:
             node[leaf] = new_tag
             changed = True
+    return changed
 
+
+def _bump_profile_list(data, new_tag: str) -> bool:
+    """Walk profile_list and rewrite every jupyterlab image ref to ``new_tag``."""
+    full_ref = f"{JUPYTERLAB_IMAGE}:{new_tag}"
+    display_ref = f"{JUPYTERLAB_DISPLAY_PREFIX}:{new_tag}"
+
+    # The chart's profile_list is loaded from ``jupyterhub.custom.profiles``
+    # by 01-spawner.py, not z2jh's ``singleuser.profileList``.
+    profiles = data.get("jupyterhub", {}).get("custom", {}).get("profiles", [])
+
+    changed = False
+    for profile in profiles:
+        outer = profile.get("kubespawner_override", {})
+        if outer.get("image", "").startswith(JUPYTERLAB_IMAGE + ":") and outer["image"] != full_ref:
+            outer["image"] = full_ref
+            changed = True
+
+        choices = (
+            profile.get("profile_options", {})
+            .get("image", {})
+            .get("choices", {})
+        )
+        for choice in choices.values():
+            if choice.get("display_name", "").startswith(JUPYTERLAB_DISPLAY_PREFIX + ":") and choice["display_name"] != display_ref:
+                choice["display_name"] = display_ref
+                changed = True
+            ks = choice.get("kubespawner_override", {})
+            if ks.get("image", "").startswith(JUPYTERLAB_IMAGE + ":") and ks["image"] != full_ref:
+                ks["image"] = full_ref
+                changed = True
+
+    return changed
+
+
+def bump(values_path: Path, short_sha: str) -> bool:
+    """Rewrite every image ref in ``values_path`` to ``sha-<short_sha>``."""
+    if not short_sha or any(c.isspace() for c in short_sha):
+        raise ValueError(f"refusing to write empty/whitespace sha: {short_sha!r}")
+
+    new_tag = f"sha-{short_sha}"
+
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    data = yaml.load(values_path)
+    changed = _bump_tag_leaves(data, new_tag) | _bump_profile_list(data, new_tag)
     if changed:
         yaml.dump(data, values_path)
     return changed

--- a/values.yaml
+++ b/values.yaml
@@ -281,6 +281,12 @@ jupyterhub:
         description: "1 CPU / 2 GB RAM — interactive notebooks, light data exploration, teaching."
         default: true
         kubespawner_override:
+          # Outer image is what jhub-apps' Create App reads for its image
+          # TextField (server-types.tsx: `type.kubespawner_override.image`).
+          # The same value sits inside profile_options.image.choices.default
+          # so the JupyterLab profile selector keeps showing it too.
+          # scripts/bump_image_tags.py syncs all three on every bump.
+          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-30fa351
           cpu_limit: 1
           cpu_guarantee: 0.5
           mem_limit: "2G"
@@ -298,6 +304,7 @@ jupyterhub:
         display_name: "Medium Instance"
         description: "4 CPU / 8 GB RAM — pandas / scikit-learn workloads on medium datasets."
         kubespawner_override:
+          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-30fa351
           cpu_limit: 4
           cpu_guarantee: 2
           mem_limit: "8G"

--- a/values.yaml
+++ b/values.yaml
@@ -286,7 +286,7 @@ jupyterhub:
           # The same value sits inside profile_options.image.choices.default
           # so the JupyterLab profile selector keeps showing it too.
           # scripts/bump_image_tags.py syncs all three on every bump.
-          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-30fa351
+          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
           cpu_limit: 1
           cpu_guarantee: 0.5
           mem_limit: "2G"
@@ -296,15 +296,15 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-30fa351"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-7788c40"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-30fa351
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
       - slug: medium-instance
         display_name: "Medium Instance"
         description: "4 CPU / 8 GB RAM — pandas / scikit-learn workloads on medium datasets."
         kubespawner_override:
-          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-30fa351
+          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
           cpu_limit: 4
           cpu_guarantee: 2
           mem_limit: "8G"
@@ -314,10 +314,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-30fa351"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-7788c40"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-30fa351
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
     # Terminal customization: controls Starship prompt in JupyterLab terminals.
     # When false, falls back to the default bash prompt.
     terminal-customization: true
@@ -366,7 +366,7 @@ jupyterhub:
     # class clears current_user — id_token_hint now reaches KC).
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterhub
-      tag: "sha-30fa351"
+      tag: "sha-7788c40"
 
     config:
       JupyterHub:
@@ -456,7 +456,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterlab
-      tag: "sha-30fa351"
+      tag: "sha-7788c40"
     defaultUrl: "/lab"
     extraEnv:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"


### PR DESCRIPTION
## Summary
Surface the JupyterLab image in the jhub-apps Create App / Server Type page.

- jhub-apps' `server-types.tsx` only renders the image TextField when `type.kubespawner_override.image` is set on the profile (see [server-types.tsx:367](https://github.com/nebari-dev/jhub-apps/blob/2026.5.1rc1/ui/src/pages/server-types/server-types.tsx#L367)). The chart was only setting the image inside `profile_options.image.choices.default.kubespawner_override.image`, so the field was hidden.
- Lift the image to each profile's outer `kubespawner_override.image`. The same value continues to live inside `profile_options.image.choices.default` so the JupyterLab profile selector keeps showing it too.
- `scripts/bump_image_tags.py` now rewrites all six locations (hub tag, singleuser tag, per-profile outer image, per-profile choice display_name, per-profile choice image) in one pass and is idempotent on a clean values.yaml.
- Image tags bumped to `sha-7788c40` (latest main build, post-#77 merge).

## Test plan
- [ ] CI passes (helm template, unit, e2e).
- [ ] On the jhub-apps Server Type page, each instance card shows an "Image" TextField pre-filled with the JupyterLab ref.
- [ ] `python scripts/bump_image_tags.py <new-sha>` rewrites all six locations and exits with `updated`; a re-run reports `unchanged`.