### PR TITLE
chore: release 0.1.0-alpha.13

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nebari-data-science-pack
 description: A Helm chart for deploying JupyterHub with jhub-apps on Kubernetes
 type: application
-version: 0.1.0-alpha.12
+version: 0.1.0-alpha.13
 appVersion: "1.0.0"
 
 dependencies:


### PR DESCRIPTION
## Summary
Bumps Chart.yaml to \`0.1.0-alpha.13\`. Cuts a release that bundles the changes merged since \`0.1.0-alpha.12\`:

- #74 — auto-wire hub OAuth from \`nebariapp.hostname\`
- #75 — IBM Plex Sans / Fira Code as JupyterLab default fonts
- #77 — bump jhub-apps to \`2026.5.1rc1\` with IBM Plex Sans font + version-footer flag
- #78 — surface image picker in jhub-apps Create App + bump image tags to \`sha-7788c40\`

## Test plan
- [ ] Release Chart workflow publishes the new chart version to the gh-pages helm repo on merge.