### PR TITLE
feat(hub): pin jhub-apps to PR #680 (perf/hub-roundtrips)

### DIFF
--- a/images/jupyterhub/pixi.lock
+++ b/images/jupyterhub/pixi.lock
@@ -208,7 +208,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d6/8a/261e724abbc35578ea4f6b4997a74fac071f4e71d90bd1604f4727fe79b4/jhub_apps-2026.5.1rc1-py3-none-any.whl
+      - pypi: git+https://github.com/nebari-dev/jhub-apps.git?rev=a260fd6c8c0b3f82121ea86c7b32315d6162a3f4#a260fd6c8c0b3f82121ea86c7b32315d6162a3f4
       - pypi: https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/64/285f20a31679bf547b75602702f7800e74dbabae36ef324f716c02804753/jupyter-1.1.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl
@@ -494,7 +494,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d6/8a/261e724abbc35578ea4f6b4997a74fac071f4e71d90bd1604f4727fe79b4/jhub_apps-2026.5.1rc1-py3-none-any.whl
+      - pypi: git+https://github.com/nebari-dev/jhub-apps.git?rev=a260fd6c8c0b3f82121ea86c7b32315d6162a3f4#a260fd6c8c0b3f82121ea86c7b32315d6162a3f4
       - pypi: https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/64/285f20a31679bf547b75602702f7800e74dbabae36ef324f716c02804753/jupyter-1.1.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl
@@ -2255,10 +2255,9 @@ packages:
   - async-timeout ; python_full_version < '3.11' and extra == 'test'
   - trio ; extra == 'trio'
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/d6/8a/261e724abbc35578ea4f6b4997a74fac071f4e71d90bd1604f4727fe79b4/jhub_apps-2026.5.1rc1-py3-none-any.whl
+- pypi: git+https://github.com/nebari-dev/jhub-apps.git?rev=a260fd6c8c0b3f82121ea86c7b32315d6162a3f4#a260fd6c8c0b3f82121ea86c7b32315d6162a3f4
   name: jhub-apps
   version: 2026.5.1rc1
-  sha256: 23a867093fa0f707b5e8e8b9ef86532272972c7beb29d6e437a58125eaebbf48
   requires_dist:
   - bokeh
   - bokeh-root-cmd

--- a/images/jupyterhub/pixi.toml
+++ b/images/jupyterhub/pixi.toml
@@ -26,7 +26,8 @@ pyjwt = ">=2.10"
 [pypi-dependencies]
 nebari-jupyterhub-theme = "==2024.7.1"
 python-keycloak = "==0.26.1"
-# 2026.5.1rc1 ships PR #677 (configurable JApps font via template_vars
-# font_family / font_url) and PR #678 (FastAPI + Starlette 1.x upgrade),
-# so the prior pyjwt<2.10 and starlette<1 caps are gone.
-jhub-apps = "==2026.5.1rc1"
+# Pinned to the head of nebari-dev/jhub-apps#680 (perf/hub-roundtrips):
+# cuts hub API roundtrips on the /home hot path. Includes PR #677
+# (configurable JApps font) and PR #678 (Starlette 1.x upgrade), so the
+# prior pyjwt<2.10 and starlette<1 caps are gone.
+jhub-apps = { git = "https://github.com/nebari-dev/jhub-apps.git", rev = "a260fd6c8c0b3f82121ea86c7b32315d6162a3f4" }

--- a/values.yaml
+++ b/values.yaml
@@ -286,7 +286,7 @@ jupyterhub:
           # The same value sits inside profile_options.image.choices.default
           # so the JupyterLab profile selector keeps showing it too.
           # scripts/bump_image_tags.py syncs all three on every bump.
-          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
+          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-03ca1c3
           cpu_limit: 1
           cpu_guarantee: 0.5
           mem_limit: "2G"
@@ -296,15 +296,15 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-7788c40"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-03ca1c3"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-03ca1c3
       - slug: medium-instance
         display_name: "Medium Instance"
         description: "4 CPU / 8 GB RAM — pandas / scikit-learn workloads on medium datasets."
         kubespawner_override:
-          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
+          image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-03ca1c3
           cpu_limit: 4
           cpu_guarantee: 2
           mem_limit: "8G"
@@ -314,10 +314,10 @@ jupyterhub:
             display_name: Image
             choices:
               default:
-                display_name: "nebari-data-science-pack-jupyterlab:sha-7788c40"
+                display_name: "nebari-data-science-pack-jupyterlab:sha-03ca1c3"
                 default: true
                 kubespawner_override:
-                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-7788c40
+                  image: quay.io/nebari/nebari-data-science-pack-jupyterlab:sha-03ca1c3
     # Terminal customization: controls Starship prompt in JupyterLab terminals.
     # When false, falls back to the default bash prompt.
     terminal-customization: true
@@ -366,7 +366,7 @@ jupyterhub:
     # class clears current_user — id_token_hint now reaches KC).
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterhub
-      tag: "sha-7788c40"
+      tag: "sha-03ca1c3"
 
     config:
       JupyterHub:
@@ -456,7 +456,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/nebari/nebari-data-science-pack-jupyterlab
-      tag: "sha-7788c40"
+      tag: "sha-03ca1c3"
     defaultUrl: "/lab"
     extraEnv:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"


### PR DESCRIPTION
## Summary
Pin \`jhub-apps\` in the hub image to nebari-dev/jhub-apps#680 head (\`a260fd6\`), which cuts hub API roundtrips on the \`/home\` hot path.

Pin moves from the tagged \`==2026.5.1rc1\` release to a git ref so we can validate the perf change in production before it lands on jhub-apps' \`main\`. Drops back to a tagged release once PR #680 merges and a new jhub-apps version cuts.

## Test plan
- [ ] CI builds the jupyterhub image and tags \`sha-<merge>\`.
- [ ] Deploy on hetzner: \`/hub/home\` measurably faster (compare hub log timings before/after).