### PR TITLE
feat(nebi-envs): default the env selector to on

### DIFF
--- a/config/jupyterhub/03-nebi-envs.py
+++ b/config/jupyterhub/03-nebi-envs.py
@@ -169,17 +169,14 @@ def get_nebi_environments(user):
 
 
 # ---------------------------------------------------------------------------
-# Register the callable with jhub-apps (only when enabled)
+# Register the callable with jhub-apps
 # ---------------------------------------------------------------------------
-_nebi_env_selector = get_config("custom.nebi-environment-selector", False)
 _nebi_internal_url = get_config("custom.nebi-internal-url", "")
 
-if _nebi_env_selector and _nebi_internal_url:
+if _nebi_internal_url:
     c.JAppsConfig.conda_envs = get_nebi_environments
     log.info("nebi-envs: environment selector enabled (nebi_url=%s)", _nebi_internal_url)
 else:
-    if _nebi_env_selector and not _nebi_internal_url:
-        log.warning(
-            "nebi-envs: nebi-environment-selector is true but nebi-internal-url is not set, "
-            "environment selector will not be enabled"
-        )
+    log.warning(
+        "nebi-envs: nebi-internal-url is not set, environment selector will not be enabled"
+    )

--- a/values.yaml
+++ b/values.yaml
@@ -261,7 +261,6 @@ jupyterhub:
     keycloak-token-url: ""   # e.g., http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari/protocol/openid-connect/token
     nebi-client-id: ""       # Nebi's Keycloak OIDC client ID
     jupyterhub-client-id: "" # JupyterHub's Keycloak OIDC client ID
-    nebi-environment-selector: false  # Set true to show nebi workspaces in jhub-apps env dropdown
     # ---------------------------------------------------------------------------
     # Profiles — resource sizing for JupyterLab pods.
     # Each entry maps directly to a KubeSpawner profile_list item. Slugs are


### PR DESCRIPTION
## Summary
- Drops `custom.nebi-environment-selector`. The Software-Environment dropdown in jhub-apps Create-App is now wired automatically whenever `custom.nebi-internal-url` is set.
- Fresh deploys that configured `nebi-internal-url` were still getting an empty dropdown because the flag defaulted to `false`, even though the rest of the wiring (token exchange, internal URL) was present.

## Test plan
- [ ] Deploy chart with `custom.nebi-internal-url` set (and the other required custom keys), no `nebi-environment-selector` in values
- [ ] Open `/services/japps/create-app` → Software Environment dropdown lists the user's ready nebi workspaces
- [ ] Deploy without `nebi-internal-url` → hub starts cleanly, warning logged, dropdown not wired