### PR TITLE
ci(build-images): skip GPU and arm64 builds on PRs

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -28,12 +28,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # PR-time CI filtering:
+  #   - GPU images (jupyterlab-gpu-base, jupyterlab-gpu) are skipped
+  #     entirely on PRs — the same Dockerfile/pixi paths are exercised
+  #     by the non-GPU variants, so PR cost should not pay for cuda
+  #     base-image pulls and gpu builder runners.
+  #   - linux/arm64 is skipped on PRs — amd64 build proves the pixi
+  #     resolution; arm64 catches per-arch wheel gaps but rarely
+  #     fails in isolation. Main builds full multi-arch.
+  # See issue #86 (section 3) for the audit that drove this.
+
   jupyterlab-base:
     name: "jupyterlab-base"
     uses: ./.github/workflows/build-image.yaml
     with:
       image: nebari-data-science-pack-jupyterlab-base
       target: jupyterlab-base
+      build_arm64: ${{ github.event_name != 'pull_request' }}
     secrets:
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
@@ -43,11 +54,13 @@ jobs:
     with:
       image: nebari-data-science-pack-jupyterlab
       target: jupyterlab
+      build_arm64: ${{ github.event_name != 'pull_request' }}
     secrets:
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
   jupyterlab-gpu-base:
     name: "jupyterlab-gpu-base"
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/build-image.yaml
     with:
       image: nebari-data-science-pack-jupyterlab-gpu-base
@@ -60,6 +73,7 @@ jobs:
 
   jupyterlab-gpu:
     name: "jupyterlab-gpu"
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/build-image.yaml
     with:
       image: nebari-data-science-pack-jupyterlab-gpu
@@ -76,5 +90,6 @@ jobs:
     with:
       image: nebari-data-science-pack-jupyterhub
       target: jupyterhub
+      build_arm64: ${{ github.event_name != 'pull_request' }}
     secrets:
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
## Summary

PR-time CI was rebuilding all five image targets (jupyterlab-base, jupyterlab, jupyterlab-gpu-base, jupyterlab-gpu, jupyterhub) multi-arch on every change to `images/**`, even though most PRs touch a single `pixi.toml` and the same Dockerfile paths get exercised by the non-GPU amd64 build. GPU images (cuda base pull + gpu builder runners) and arm64 runners are the bulk of the runtime.

Changes:

- `jupyterlab-gpu-base` and `jupyterlab-gpu` jobs gated on `if: github.event_name != 'pull_request'` — skipped entirely on PRs.
- Non-GPU callers pass `build_arm64: ${{ github.event_name != 'pull_request' }}` — PRs build amd64 only.
- Main pushes, tag pushes, and `workflow_dispatch` keep the full multi-arch matrix.

The `merge` job in `build-image.yaml` has `needs: [build-amd64, build-arm64]` with `if: "!cancelled() && !failure()"`, which still runs when `build-arm64` is skipped. `docker buildx imagetools create` produces a single-platform manifest list cleanly from one digest.

This is the second of three follow-ups from #86. PR #88 (fork-PR skip) is the first; the e2e-consumes-build-artifact change will follow.

## Test plan

- [ ] This PR's own run: verify only `jupyterlab-base`, `jupyterlab`, `jupyterhub` jobs run; each runs amd64 only; merge produces a single-arch `pr-NN` manifest in quay/ghcr
- [ ] After merge, the main-branch run rebuilds full multi-arch + GPU variants and tags `sha-<new>` / `main` / `latest` as before
- [ ] Verify a deploy off the `pr-NN` tag works on a test cluster (would catch any single-arch manifest deployment quirks)

Refs #86, #88.