### PR TITLE
ci(build-image): hotfix `env` context not available at job-level `if:`

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -50,6 +50,11 @@ env:
   #     supply-chain risk (see issue #86)
   # Fork PRs still build (no push) so the Dockerfile/pixi config
   # is validated. Same-repo PRs and non-PR events are unchanged.
+  #
+  # NOTE: this env var is referenced from step-level `if:` only.
+  # GitHub Actions does not expose the `env` context to job-level
+  # `if:` expressions, so the `merge` job inlines the same condition
+  # directly. Keep the two in sync.
   IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
 
 jobs:
@@ -165,7 +170,9 @@ jobs:
     name: "Merge"
     runs-on: ubuntu-latest
     # Fork PRs have nothing to merge (no digests pushed); skip entirely.
-    if: "!cancelled() && !failure() && env.IS_FORK_PR != 'true'"
+    # Inlined because job-level `if:` cannot read the `env` context —
+    # keep this expression in sync with workflow-level IS_FORK_PR.
+    if: "!cancelled() && !failure() && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)"
     needs: [build-amd64, build-arm64]
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
## Summary

Hotfix for the regression I introduced in #88. The merge job's `if:` referenced `env.IS_FORK_PR`, but the `env` context is only exposed to **step-level** `if:` expressions, not job-level ones. The workflow failed to parse the first time it ran on main after #88 merged (run [26239055218](https://github.com/nebari-dev/nebari-data-science-pack/actions/runs/26239055218)):

```
Invalid workflow file
(Line: 168, Col: 9): Unrecognized named-value: 'env'.
Located at position 31 within expression:
!cancelled() && !failure() && env.IS_FORK_PR != 'true'
```

This blocks every subsequent `build-images.yaml` run on main and on any PR that triggers it.

## Fix

Inline the IS_FORK_PR expression directly at the merge job's `if:`. Step-level uses of `env.IS_FORK_PR` (inside `build-amd64` / `build-arm64`) are valid and untouched. Added a NOTE on the env var documenting the job-level limitation so the same mistake doesn't recur.

The inlined expression is functionally equivalent:

```yaml
if: "!cancelled() && !failure() && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)"
```

## Test plan

- [x] CI parses the workflow cleanly on this PR's own run
- [ ] After merge, the next `images/**` push to main triggers `build-images.yaml` without the "Unrecognized named-value" error
- [ ] Same-repo PRs (this one) still run the merge job; fork PRs still skip it

Refs #88, #86.