### PR TITLE
chore: bump nebi to v0.12-rc2 (sha-d33bb7e)

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -113,7 +113,7 @@ FROM ${NEBI_IMAGE:-scratch} AS nebi-source
 # ========== jupyterlab (base + nebi) ===========
 FROM jupyterlab-base AS jupyterlab
 
-ARG NEBI_VERSION=0.10.3
+ARG NEBI_VERSION=0.12-rc2
 ARG TARGETARCH
 
 # Install nebi: copy from NEBI_IMAGE if provided, else download from GitHub release.

--- a/values.yaml
+++ b/values.yaml
@@ -221,7 +221,7 @@ nebi:
     # Pinned per chart release by CI (scripts/bump_image_tags.py); deployers
     # can override to test a PR build or roll forward. Leave non-empty so
     # the init container is wired by default.
-    tag: "sha-f024a78"
+    tag: "sha-d33bb7e"
     pullPolicy: IfNotPresent
   # External Nebi FQDN (browser-side, used for OIDC redirect).
   # If empty, derived from keycloak.hostname as


### PR DESCRIPTION
Bump nebi to v0.12-rc2 (`sha-d33bb7e`). Group-based RBAC (native + OIDC-synced groups) plus the OIDC group-path dedup fix (#370).