### PR TITLE
test: pin launchpad#80 + nb_nebi_kernels#5 for integration build [DO NOT MERGE]

### DIFF
--- a/images/jupyterlab/pixi.lock
+++ b/images/jupyterlab/pixi.lock
@@ -414,6 +414,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - pypi: git+https://github.com/MUFFANUJ/jupyterlab-launchpad.git?branch=nebi-kernel-metadata-refresh#28cc06b61e3ef1302b4fc669d9fce84149dacb06
+      - pypi: git+https://github.com/MUFFANUJ/nb-nebi-kernels.git?branch=surfaceRemoteEvns#ebbb50ffb80aeae74a1e70647a24fcc09b14e307
       - pypi: git+https://github.com/betatim/vscode-binder.git#25d70ec4ca208d01a6bcbfd616de1b2b2c7d431c
       - pypi: https://files.pythonhosted.org/packages/02/11/9cae49425dbb3e89a7bb3a4d2e974711ad86baa6cc1f47c9bb4e009adced/jupyterlab_jhub_apps-0.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
@@ -463,12 +465,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/3e/8228047497767397d5e9ef195fb2739b6ed755d042ad3c0edb28f4f6d578/conda_lock-3.0.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/cc/7e/e0cc8c945693b9e28cc45d45145f2cf1670cca587da5a96f05371d4bf46e/jupyterlab_launchpad-1.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/da/e5/148ab5edb339f5833d04f0bcb8380a53e8b19bd5f091ae67222ed188b393/uv-0.9.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -887,6 +887,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - pypi: git+https://github.com/MUFFANUJ/jupyterlab-launchpad.git?branch=nebi-kernel-metadata-refresh#28cc06b61e3ef1302b4fc669d9fce84149dacb06
+      - pypi: git+https://github.com/MUFFANUJ/nb-nebi-kernels.git?branch=surfaceRemoteEvns#ebbb50ffb80aeae74a1e70647a24fcc09b14e307
       - pypi: git+https://github.com/betatim/vscode-binder.git#25d70ec4ca208d01a6bcbfd616de1b2b2c7d431c
       - pypi: https://files.pythonhosted.org/packages/02/11/9cae49425dbb3e89a7bb3a4d2e974711ad86baa6cc1f47c9bb4e009adced/jupyterlab_jhub_apps-0.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/57/7163ed06a2d9bf1f34d89dcc7c5881119beeed287022c997b0a706edcfbe/dulwich-0.22.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -936,12 +938,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/3e/8228047497767397d5e9ef195fb2739b6ed755d042ad3c0edb28f4f6d578/conda_lock-3.0.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/cc/7e/e0cc8c945693b9e28cc45d45145f2cf1670cca587da5a96f05371d4bf46e/jupyterlab_launchpad-1.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
@@ -8782,6 +8782,21 @@ packages:
   - pkg:pypi/zipp?source=hash-mapping
   size: 21809
   timestamp: 1732827613585
+- pypi: git+https://github.com/MUFFANUJ/jupyterlab-launchpad.git?branch=nebi-kernel-metadata-refresh#28cc06b61e3ef1302b4fc669d9fce84149dacb06
+  name: jupyterlab-launchpad
+  version: 1.0.5
+  requires_dist:
+  - jupyter-server>=2.0.1,<3
+  - jupyter-server-proxy ; extra == 'test'
+  requires_python: '>=3.8'
+- pypi: git+https://github.com/MUFFANUJ/nb-nebi-kernels.git?branch=surfaceRemoteEvns#ebbb50ffb80aeae74a1e70647a24fcc09b14e307
+  name: nb-nebi-kernels
+  version: 0.1.dev24+gebbb50ffb
+  requires_dist:
+  - jupyter-client>=8.0.0
+  - jupyter-core>=5.0.0
+  - jupyter-server>=2.0.0
+  requires_python: '>=3.10'
 - pypi: git+https://github.com/betatim/vscode-binder.git#25d70ec4ca208d01a6bcbfd616de1b2b2c7d431c
   name: jupyter-vscode-proxy
   version: '0.7'
@@ -9375,15 +9390,6 @@ packages:
   version: 0.13.3
   sha256: c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/c1/bb/ff2ec25b56acabf288b38cdc977619347ab6e0f98c119cf0101f6644d904/nb_nebi_kernels-0.1-py3-none-any.whl
-  name: nb-nebi-kernels
-  version: '0.1'
-  sha256: cf6494d685112e43c38f04cb706320db96c526448411ca1c31f358caa50a54d4
-  requires_dist:
-  - jupyter-client>=8.0.0
-  - jupyter-core>=5.0.0
-  - jupyter-server>=2.0.0
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
   name: tomli-w
   version: 1.2.0
@@ -9449,14 +9455,6 @@ packages:
   - xattr>=1.0.0,<2.0.0 ; sys_platform == 'darwin'
   - zstandard>=0.15
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/cc/7e/e0cc8c945693b9e28cc45d45145f2cf1670cca587da5a96f05371d4bf46e/jupyterlab_launchpad-1.0.5-py3-none-any.whl
-  name: jupyterlab-launchpad
-  version: 1.0.5
-  sha256: 14d7455c4f16d22f8a866c38a804c5ad0ac5ebc752da6c7e72d35805f7ea3551
-  requires_dist:
-  - jupyter-server>=2.0.1,<3
-  - jupyter-server-proxy ; extra == 'test'
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
   name: tqdm
   version: 4.67.1

--- a/images/jupyterlab/pixi.toml
+++ b/images/jupyterlab/pixi.toml
@@ -16,6 +16,11 @@ jupyter_server = ">=2.13.0"
 # still uses in its extension manager. Pin httpx <0.28 until JupyterLab is upgraded.
 httpx = "<0.28"
 jupyterlab = "==4.2.5"
+# Make nodejs explicit (already pulled in transitively): the git-pinned
+# jupyterlab-launchpad below is a TS/JS extension that runs `jlpm build:prod` via its
+# hatch-jupyter-builder hook at install time, so node must be on PATH. Drop once
+# launchpad is pinned back to a prebuilt PyPI wheel.
+nodejs = ">=20"
 jupyter_client = "*"
 jupyter_console = "*"
 jupyterhub = "==5.1.0"
@@ -76,11 +81,14 @@ pyjwt = "<2.10.0"
 
 [pypi-dependencies]
 jupyter-vscode-proxy = { git = "https://github.com/betatim/vscode-binder.git" }
-nb_nebi_kernels = "==0.1"
+# TEST PIN (DO NOT MERGE): nb-nebi-kernels#5 surfaces remote Nebi envs as kernels
+# with nebi_* state metadata; jupyterlab-launchpad#80 consumes that metadata. Pinned
+# together for end-to-end validation. Revert to released versions once both PRs land.
+nb_nebi_kernels = { git = "https://github.com/MUFFANUJ/nb-nebi-kernels.git", branch = "surfaceRemoteEvns" }
 jupyterlab_nvdashboard = "==0.12.0"
 # argo-jupyter-scheduler = "==2024.6.1"  # disabled until service is configured
 jhub-apps = "==2025.11.1"
 jupyterlab-nebari-mode = "==0.3.0"
-jupyterlab-launchpad = "==1.0.5"
+jupyterlab-launchpad = { git = "https://github.com/MUFFANUJ/jupyterlab-launchpad.git", branch = "nebi-kernel-metadata-refresh" }
 jupyterlab-gallery = "==0.6.3"
 jupyterlab-jhub-apps = "==0.3.1"


### PR DESCRIPTION
## Summary

**DO NOT MERGE.** Integration-test scaffolding so CI builds a singleuser image
that carries the remote-Nebi-kernel work end to end — the backend that emits
state metadata *and* the frontend that renders it.

Pins the singleuser image's two Nebi-related deps in
`images/jupyterlab/pixi.toml` to MUFFANUJ's open PR branches:

| dep | from | to |
|---|---|---|
| `nb_nebi_kernels` | `==0.1` | `git+https://github.com/MUFFANUJ/nb-nebi-kernels.git@surfaceRemoteEvns` |
| `jupyterlab-launchpad` | `==1.0.5` | `git+https://github.com/MUFFANUJ/jupyterlab-launchpad.git@nebi-kernel-metadata-refresh` |

The two are pinned together on purpose: `jupyterlab-launchpad`'s new state
badges / sort ranking / `refresh-kernels` command only render meaningful data
when the kernelspec manager emits the `nebi_*` metadata, which is exactly what
the `nb-nebi-kernels` branch adds. Pinning only the frontend would load the
code against an empty metadata contract.

## What's in the diff

- `images/jupyterlab/pixi.toml`
  - the two git pins above (locked to `28cc06b` launchpad / `ebbb50f` kernels)
  - `nodejs = ">=20"` made explicit. `jupyterlab-launchpad` is a TS/JS
    extension whose git source builds via a `jlpm build:prod`
    hatch-jupyter-builder hook (the branch gitignores the prebuilt
    `labextension/`), so node must be on PATH during `pixi install`. It was
    already present transitively via `jupyterlab`; pinning it explicitly keeps
    the source build from silently breaking if that transitive edge moves.
- `images/jupyterlab/pixi.lock` — regenerated so `pixi install --locked`
  (used by `images/Dockerfile`) resolves both git sources. No new transitive
  Python deps; no incidental `jupyter-vscode-proxy` HEAD drift this time.

## Test plan

- [ ] `Build Docker Images` produces `quay.io/nebari/nebari-data-science-pack-jupyterlab:pr-<n>` (amd64 + arm64). **Watch the launchpad `jlpm build:prod` step** — first git-sourced JS extension in this image, so the node build path is exercised for the first time.
- [ ] `Test Deployment` (k3d) passes — singleuser env installs without breaking.
- [ ] Manual smoke on the Hetzner Nebari deploy: with `NEBI_REMOTE_URL` + JWT in the pod, remote-only workspaces surface as `remote-not-pulled` kernels and local kernels classify (`ready` / `local-not-installed` / `local-missing-deps`) in the launcher.

## References

This image build is the integration vehicle for:

- Tracking issue: nebari-dev/nb-nebi-kernels#2 (surface remote envs, state, drift, missing-dep, refresh)
- Backend PR: nebari-dev/nb-nebi-kernels#5 (surface remote Nebi kernels)
- Frontend PR: nebari-dev/jupyterlab-launchpad#80 (consume `nb-nebi-kernels` state metadata + refresh trigger)
- Supersedes the kernels-only test pin in #59 (closed)

Once both upstream PRs land and a `nb-nebi-kernels` release is cut, the
production pins bump to the tagged versions and this branch is dropped.
