### PR TITLE
feat: gate JupyterHub profiles by Keycloak group membership

### DIFF
--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -185,9 +185,101 @@ c.KubeSpawner.environment = env
 # ``kubespawner_override`` accepts any valid KubeSpawner trait so deployers
 # can add node_selector, image, extra_resource_limits (GPU), etc. without
 # code changes. Empty list = no profile selector (single-instance mode).
+# Keys used only for group gating; KubeSpawner must never see them.
+_PROFILE_GATING_KEYS = ("access", "groups", "users")
+
+
+def _get_profile_groups(auth_state):
+    """Resolve the user's full Keycloak group list for profile gating.
+
+    Unlike _get_user_groups (shared-storage), this uses the user's COMPLETE
+    group list — not the mount-role gated subset and not the shared-storage
+    allowlist — so profile visibility does not depend on shared-storage RBAC
+    being deployed. Group names are normalised to the leaf segment
+    (/projects/foo -> foo) and deduplicated, matching classic Nebari.
+    """
+    if not auth_state:
+        return []
+    raw_groups = auth_state.get("groups")
+    if raw_groups is None:
+        raw_groups = (auth_state.get("oauth_user") or {}).get("groups", [])
+
+    seen = set()
+    result = []
+    for g in raw_groups or []:
+        name = Path(g).name
+        if name and name not in seen:
+            seen.add(name)
+            result.append(name)
+    return result
+
+
+def _profile_username(auth_state):
+    """Username matched against a profile's ``users`` list.
+
+    Uses the Keycloak ``preferred_username`` (mirrors classic Nebari) so it
+    resolves identically in the spawner and in jhub-apps' fake-spawner path,
+    where ``spawner.user.name`` is a Mock rather than a real username.
+    """
+    oauth_user = (auth_state or {}).get("oauth_user") or {}
+    return oauth_user.get("preferred_username") or ""
+
+
+def _filter_profiles(profiles, groups, username):
+    """Return the profiles a user may select, stripped of gating-only keys.
+
+    Mirrors classic Nebari's ``access:`` semantics on each profile:
+      * ``access: all`` (or omitted) — visible to everyone.
+      * ``access: yaml`` — visible only if the user is in the profile's
+        ``users`` list or shares one of the profile's ``groups``.
+    """
+    group_set = set(groups)
+    visible = []
+    for profile in profiles:
+        access = profile.get("access", "all")
+        if access == "yaml":
+            in_users = username in set(profile.get("users") or [])
+            in_groups = bool(group_set & set(profile.get("groups") or []))
+            if not in_users and not in_groups:
+                continue
+        elif access != "all":
+            # Fail closed on an unrecognized access mode: restricted profiles
+            # gate expensive resources, so a typo must hide the profile rather
+            # than expose it to everyone.
+            log.warning(
+                "profiles: hiding %r — unsupported access mode %r (use 'all' or 'yaml')",
+                profile.get("slug") or profile.get("display_name"),
+                access,
+            )
+            continue
+        clean = {k: v for k, v in profile.items() if k not in _PROFILE_GATING_KEYS}
+        visible.append(clean)
+    return visible
+
+
+async def _render_profile_list(spawner):
+    """Per-user profile_list callable — filters profiles by group membership.
+
+    KubeSpawner (and jhub-apps' server-types endpoint) accept an async callable
+    here and invoke it with the spawner at selection time. We resolve the
+    user's Keycloak groups from auth_state and return only the profiles they
+    are allowed to see, with gating-only keys stripped.
+    """
+    auth_state = await spawner.user.get_auth_state()
+    groups = _get_profile_groups(auth_state)
+    username = _profile_username(auth_state)
+    visible = _filter_profiles(_profiles, groups, username)
+    log.info(
+        "profiles: user %s (groups=%s) sees %d/%d profile(s): %s",
+        username, groups, len(visible), len(_profiles),
+        [p.get("slug") or p.get("display_name") for p in visible],
+    )
+    return visible
+
+
 _profiles = get_config("custom.profiles", [])
 if _profiles:
-    c.KubeSpawner.profile_list = _profiles
+    c.KubeSpawner.profile_list = _render_profile_list
     log.info(
         "profiles: loaded %d profile(s): %s",
         len(_profiles),

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -214,6 +214,17 @@ def _get_profile_groups(auth_state):
     return result
 
 
+def _get_keycloak_profile_names(auth_state):
+    """Profile display_names allowed via ``access: keycloak``.
+
+    Read from the user's ``jupyterlab_profiles`` claim, which a Keycloak
+    attribute mapper stamps into the token from the user's group/user
+    attributes (matches classic Nebari).
+    """
+    oauth_user = (auth_state or {}).get("oauth_user") or {}
+    return oauth_user.get("jupyterlab_profiles", []) or []
+
+
 def _profile_username(auth_state):
     """Username matched against a profile's ``users`` list.
 
@@ -225,15 +236,19 @@ def _profile_username(auth_state):
     return oauth_user.get("preferred_username") or ""
 
 
-def _filter_profiles(profiles, groups, username):
+def _filter_profiles(profiles, groups, username, keycloak_profile_names=()):
     """Return the profiles a user may select, stripped of gating-only keys.
 
     Mirrors classic Nebari's ``access:`` semantics on each profile:
       * ``access: all`` (or omitted) — visible to everyone.
       * ``access: yaml`` — visible only if the user is in the profile's
         ``users`` list or shares one of the profile's ``groups``.
+      * ``access: keycloak`` — visible only if the profile's ``display_name``
+        is in the user's ``jupyterlab_profiles`` claim, which a Keycloak
+        attribute mapper stamps into the token from group/user attributes.
     """
     group_set = set(groups)
+    profile_name_set = set(keycloak_profile_names)
     visible = []
     for profile in profiles:
         access = profile.get("access", "all")
@@ -242,12 +257,16 @@ def _filter_profiles(profiles, groups, username):
             in_groups = bool(group_set & set(profile.get("groups") or []))
             if not in_users and not in_groups:
                 continue
+        elif access == "keycloak":
+            if profile.get("display_name") not in profile_name_set:
+                continue
         elif access != "all":
             # Fail closed on an unrecognized access mode: restricted profiles
             # gate expensive resources, so a typo must hide the profile rather
             # than expose it to everyone.
             log.warning(
-                "profiles: hiding %r — unsupported access mode %r (use 'all' or 'yaml')",
+                "profiles: hiding %r — unsupported access mode %r "
+                "(use 'all', 'yaml', or 'keycloak')",
                 profile.get("slug") or profile.get("display_name"),
                 access,
             )
@@ -268,7 +287,8 @@ async def _render_profile_list(spawner):
     auth_state = await spawner.user.get_auth_state()
     groups = _get_profile_groups(auth_state)
     username = _profile_username(auth_state)
-    visible = _filter_profiles(_profiles, groups, username)
+    keycloak_profile_names = _get_keycloak_profile_names(auth_state)
+    visible = _filter_profiles(_profiles, groups, username, keycloak_profile_names)
     log.info(
         "profiles: user %s (groups=%s) sees %d/%d profile(s): %s",
         username, groups, len(visible), len(_profiles),

--- a/tests/unit/test_spawner_profiles.py
+++ b/tests/unit/test_spawner_profiles.py
@@ -1,0 +1,208 @@
+"""Tests for per-profile group gating in `01-spawner.py`.
+
+The data science pack mirrors classic Nebari's ``access:`` semantics on each
+``custom.profiles`` entry:
+
+  * ``access: all`` (or omitted) — every authenticated user sees the profile.
+  * ``access: yaml`` — only users in the listed ``groups``/``users`` see it.
+
+Gating is applied per user at spawn time by setting
+``c.KubeSpawner.profile_list`` to an async callable. The callable resolves the
+user's Keycloak groups from ``auth_state`` and returns only the admitted
+profiles, with the gating-only keys (``access``/``groups``/``users``) stripped
+so KubeSpawner never sees them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+# 01-spawner.py imports `z2jh.get_config`; stub it so the module can be exec'd
+# standalone in the host venv.
+sys.modules.setdefault("z2jh", types.ModuleType("z2jh"))
+# Reference whichever z2jh module actually landed in sys.modules (another test
+# module may have registered its own stub first via setdefault).
+_z2jh = sys.modules["z2jh"]
+_z2jh.get_config = lambda key, default=None: default
+
+from conftest import FakeConfig, load_config_module  # noqa: E402
+
+
+def _load():
+    c = FakeConfig()
+    return load_config_module("01-spawner.py", inject_c=c), c
+
+
+def test_profile_without_access_is_visible_to_all():
+    """A profile with no ``access`` key is shown to every user (current behavior)."""
+    mod, _ = _load()
+
+    profiles = [{"slug": "small", "display_name": "Small"}]
+    visible = mod._filter_profiles(profiles, groups=[], username="alice")
+
+    assert visible == [{"slug": "small", "display_name": "Small"}]
+
+
+def test_yaml_access_visible_when_group_matches_and_keys_stripped():
+    """A restricted profile is shown to a user in one of its groups, and the
+    gating-only keys never reach KubeSpawner."""
+    mod, _ = _load()
+
+    profiles = [
+        {
+            "slug": "gpu",
+            "display_name": "GPU",
+            "access": "yaml",
+            "groups": ["gpu-access"],
+            "kubespawner_override": {"extra_resource_limits": {"nvidia.com/gpu": 1}},
+        }
+    ]
+    visible = mod._filter_profiles(profiles, groups=["gpu-access"], username="alice")
+
+    assert visible == [
+        {
+            "slug": "gpu",
+            "display_name": "GPU",
+            "kubespawner_override": {"extra_resource_limits": {"nvidia.com/gpu": 1}},
+        }
+    ]
+
+
+def test_yaml_access_hidden_when_user_not_in_groups_or_users():
+    """A restricted profile is hidden from a user in none of its groups/users."""
+    mod, _ = _load()
+
+    profiles = [
+        {"slug": "gpu", "display_name": "GPU", "access": "yaml", "groups": ["gpu-access"]}
+    ]
+    visible = mod._filter_profiles(profiles, groups=["data-team"], username="alice")
+
+    assert visible == []
+
+
+def test_yaml_access_visible_when_user_in_users_list():
+    """A restricted profile is shown to a named user even with no group match."""
+    mod, _ = _load()
+
+    profiles = [
+        {
+            "slug": "gpu",
+            "display_name": "GPU",
+            "access": "yaml",
+            "groups": ["gpu-access"],
+            "users": ["alice"],
+        }
+    ]
+    visible = mod._filter_profiles(profiles, groups=["data-team"], username="alice")
+
+    assert [p["slug"] for p in visible] == ["gpu"]
+
+
+def test_unknown_access_value_is_hidden():
+    """An unrecognized access mode fails closed (hidden), not open.
+
+    Restricted profiles gate expensive resources; an access typo must never
+    silently expose a GPU/large profile to everyone."""
+    mod, _ = _load()
+
+    profiles = [{"slug": "gpu", "display_name": "GPU", "access": "keycloak"}]
+    visible = mod._filter_profiles(profiles, groups=["gpu-access"], username="alice")
+
+    assert visible == []
+
+
+def test_get_profile_groups_normalizes_and_dedups():
+    """Group names are reduced to the leaf (/projects/foo -> foo) and deduped.
+
+    Profile gating uses the user's FULL group list, not the mount-role gated
+    subset — so it does not depend on shared-storage RBAC being deployed."""
+    mod, _ = _load()
+
+    auth_state = {"groups": ["/projects/foo", "gpu-access", "foo"]}
+    groups = mod._get_profile_groups(auth_state)
+
+    assert groups == ["foo", "gpu-access"]
+
+
+def test_get_profile_groups_empty_without_auth_state():
+    mod, _ = _load()
+
+    assert mod._get_profile_groups(None) == []
+
+
+def test_profile_username_prefers_preferred_username():
+    """The name matched against ``users:`` is the Keycloak preferred_username,
+    matching classic Nebari (works in the jhub-apps fake-spawner path too)."""
+    mod, _ = _load()
+
+    auth_state = {"oauth_user": {"preferred_username": "alice"}}
+    assert mod._profile_username(auth_state) == "alice"
+
+
+class _FakeUser:
+    def __init__(self, auth_state):
+        self._auth_state = auth_state
+
+    async def get_auth_state(self):
+        return self._auth_state
+
+
+class _FakeSpawner:
+    def __init__(self, auth_state):
+        self.user = _FakeUser(auth_state)
+
+
+def test_render_profile_list_filters_for_the_spawning_user(monkeypatch):
+    """The async callable resolves the user's groups from auth_state and
+    returns only the admitted profiles (gating keys stripped)."""
+    mod, _ = _load()
+
+    profiles = [
+        {"slug": "small", "display_name": "Small"},
+        {"slug": "gpu", "display_name": "GPU", "access": "yaml", "groups": ["gpu-access"]},
+    ]
+    monkeypatch.setattr(mod, "_profiles", profiles, raising=False)
+
+    auth_state = {
+        "groups": ["/gpu-access"],
+        "oauth_user": {"preferred_username": "alice"},
+    }
+    visible = asyncio.run(mod._render_profile_list(_FakeSpawner(auth_state)))
+
+    assert [p["slug"] for p in visible] == ["small", "gpu"]
+    assert all("access" not in p for p in visible)
+
+
+def test_render_profile_list_hides_restricted_profile_from_outsider():
+    mod, _ = _load()
+
+    mod._profiles = [
+        {"slug": "small", "display_name": "Small"},
+        {"slug": "gpu", "display_name": "GPU", "access": "yaml", "groups": ["gpu-access"]},
+    ]
+    auth_state = {"groups": ["data-team"], "oauth_user": {"preferred_username": "bob"}}
+    visible = asyncio.run(mod._render_profile_list(_FakeSpawner(auth_state)))
+
+    assert [p["slug"] for p in visible] == ["small"]
+
+
+def test_profile_list_is_the_filtering_callable_when_profiles_configured():
+    """When profiles exist, KubeSpawner.profile_list is wired to the per-user
+    callable, not the raw static list."""
+    # Patch the live z2jh module (another test may have swapped it via
+    # sys.modules["z2jh"] = ...), so 01-spawner's `from z2jh import get_config`
+    # picks up the profiles below.
+    z2jh = sys.modules["z2jh"]
+    prior = z2jh.get_config
+    z2jh.get_config = lambda key, default=None: (
+        [{"slug": "small", "display_name": "Small"}]
+        if key == "custom.profiles"
+        else default
+    )
+    try:
+        mod, c = _load()
+        assert c.KubeSpawner.profile_list is mod._render_profile_list
+    finally:
+        z2jh.get_config = prior

--- a/tests/unit/test_spawner_profiles.py
+++ b/tests/unit/test_spawner_profiles.py
@@ -107,8 +107,35 @@ def test_unknown_access_value_is_hidden():
     silently expose a GPU/large profile to everyone."""
     mod, _ = _load()
 
-    profiles = [{"slug": "gpu", "display_name": "GPU", "access": "keycloak"}]
+    profiles = [{"slug": "gpu", "display_name": "GPU", "access": "ldap"}]
     visible = mod._filter_profiles(profiles, groups=["gpu-access"], username="alice")
+
+    assert visible == []
+
+
+def test_keycloak_access_visible_when_display_name_in_profile_attribute():
+    """access: keycloak shows a profile only if its display_name is in the
+    user's ``jupyterlab_profiles`` claim (Keycloak attribute mapper), matching
+    classic Nebari. Gating keys are stripped."""
+    mod, _ = _load()
+
+    profiles = [
+        {"slug": "gpu", "display_name": "GPU", "access": "keycloak"},
+    ]
+    visible = mod._filter_profiles(
+        profiles, groups=[], username="alice", keycloak_profile_names=["GPU"]
+    )
+
+    assert visible == [{"slug": "gpu", "display_name": "GPU"}]
+
+
+def test_keycloak_access_hidden_when_display_name_not_in_attribute():
+    mod, _ = _load()
+
+    profiles = [{"slug": "gpu", "display_name": "GPU", "access": "keycloak"}]
+    visible = mod._filter_profiles(
+        profiles, groups=[], username="alice", keycloak_profile_names=["Other"]
+    )
 
     assert visible == []
 
@@ -130,6 +157,40 @@ def test_get_profile_groups_empty_without_auth_state():
     mod, _ = _load()
 
     assert mod._get_profile_groups(None) == []
+
+
+def test_get_keycloak_profile_names_reads_oauth_user_attribute():
+    """The keycloak-mode profile names come from the oauth_user
+    ``jupyterlab_profiles`` claim, matching classic Nebari."""
+    mod, _ = _load()
+
+    auth_state = {"oauth_user": {"jupyterlab_profiles": ["GPU", "High RAM"]}}
+    assert mod._get_keycloak_profile_names(auth_state) == ["GPU", "High RAM"]
+
+
+def test_get_keycloak_profile_names_empty_without_attribute():
+    mod, _ = _load()
+
+    assert mod._get_keycloak_profile_names({"oauth_user": {}}) == []
+    assert mod._get_keycloak_profile_names(None) == []
+
+
+def test_render_profile_list_applies_keycloak_attribute_gating():
+    """The async callable threads jupyterlab_profiles into keycloak gating."""
+    mod, _ = _load()
+
+    mod._profiles = [
+        {"slug": "small", "display_name": "Small"},
+        {"slug": "gpu", "display_name": "GPU", "access": "keycloak"},
+        {"slug": "hpc", "display_name": "HPC", "access": "keycloak"},
+    ]
+    auth_state = {
+        "groups": [],
+        "oauth_user": {"preferred_username": "alice", "jupyterlab_profiles": ["GPU"]},
+    }
+    visible = asyncio.run(mod._render_profile_list(_FakeSpawner(auth_state)))
+
+    assert [p["slug"] for p in visible] == ["small", "gpu"]
 
 
 def test_profile_username_prefers_preferred_username():

--- a/values.yaml
+++ b/values.yaml
@@ -359,6 +359,25 @@ jupyterhub:
     # kubespawner_override accepts any valid KubeSpawner trait (cpu_limit,
     # mem_limit, node_selector, image, extra_resource_limits, etc.) so deployers
     # can add GPU profiles, custom images, etc. without code changes.
+    #
+    # Per-profile group gating (parity with classic Nebari). Each entry may
+    # declare an ``access`` mode that controls who sees it in the selector:
+    #   access: all   (or omitted) profile is visible to every user.
+    #   access: yaml  profile is visible only to users whose Keycloak groups
+    #                 intersect ``groups``, or whose preferred_username is in
+    #                 ``users``. A user in none of these never sees it.
+    # Any other access value fails closed (the profile is hidden) so a typo
+    # cannot expose an expensive GPU/large-instance profile to everyone.
+    # The ``access``/``groups``/``users`` keys are gating-only and are stripped
+    # before the profile reaches KubeSpawner. Groups come from the same
+    # Keycloak group claim used by shared storage. Example:
+    #   - display_name: "G4 GPU Instance"
+    #     access: yaml
+    #     groups:
+    #       - gpu-access
+    #     kubespawner_override:
+    #       extra_resource_limits:
+    #         nvidia.com/gpu: 1
     # NOTE: when bumping singleuser.image.tag below, also bump the
     # ``image: ...`` lines inside each profile_options.image.choices.default
     # entry so the profile selector shows the right tag. (z2jh values.yaml

--- a/values.yaml
+++ b/values.yaml
@@ -362,10 +362,16 @@ jupyterhub:
     #
     # Per-profile group gating (parity with classic Nebari). Each entry may
     # declare an ``access`` mode that controls who sees it in the selector:
-    #   access: all   (or omitted) profile is visible to every user.
-    #   access: yaml  profile is visible only to users whose Keycloak groups
-    #                 intersect ``groups``, or whose preferred_username is in
-    #                 ``users``. A user in none of these never sees it.
+    #   access: all       (or omitted) profile is visible to every user.
+    #   access: yaml      profile is visible only to users whose Keycloak
+    #                     groups intersect ``groups``, or whose
+    #                     preferred_username is in ``users``. A user in none of
+    #                     these never sees it.
+    #   access: keycloak  profile is visible only when its ``display_name`` is
+    #                     in the user's ``jupyterlab_profiles`` claim. That
+    #                     claim is populated by a Keycloak attribute mapper
+    #                     from the user's group/user attributes, so the
+    #                     allow-list lives in Keycloak rather than in this file.
     # Any other access value fails closed (the profile is hidden) so a typo
     # cannot expose an expensive GPU/large-instance profile to everyone.
     # The ``access``/``groups``/``users`` keys are gating-only and are stripped


### PR DESCRIPTION
Closes #100

Per-profile gating for `custom.profiles`, mirroring classic Nebari's `access:` modes:

- `all` (or omitted): visible to everyone.
- `yaml`: visible only if the user's Keycloak groups hit `groups`, or username is in `users`.
- `keycloak`: visible only if the profile's `display_name` is in the user's `jupyterlab_profiles` claim.
- anything else: fails closed (hidden).

`profile_list` becomes a per-user async callable; `access`/`groups`/`users` are stripped before KubeSpawner sees them. Group source matches shared storage.

16 unit tests. Docs + example in `values.yaml`.