### PR TITLE
chore: bump nebi to v0.12-rc3 (sha-32d0bc9)

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -113,7 +113,7 @@ FROM ${NEBI_IMAGE:-scratch} AS nebi-source
 # ========== jupyterlab (base + nebi) ===========
 FROM jupyterlab-base AS jupyterlab
 
-ARG NEBI_VERSION=0.12-rc2
+ARG NEBI_VERSION=0.12-rc3
 ARG TARGETARCH
 
 # Install nebi: copy from NEBI_IMAGE if provided, else download from GitHub release.

--- a/values.yaml
+++ b/values.yaml
@@ -221,7 +221,7 @@ nebi:
     # Pinned per chart release by CI (scripts/bump_image_tags.py); deployers
     # can override to test a PR build or roll forward. Leave non-empty so
     # the init container is wired by default.
-    tag: "sha-d33bb7e"
+    tag: "sha-32d0bc9"
     pullPolicy: IfNotPresent
   # External Nebi FQDN (browser-side, used for OIDC redirect).
   # If empty, derived from keycloak.hostname as


### PR DESCRIPTION
Bump nebi to v0.12-rc3 (`sha-32d0bc9`).