### PR TITLE
chore: bump chart version to 0.1.0-alpha.14

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nebari-data-science-pack
 description: A Helm chart for deploying JupyterHub with jhub-apps on Kubernetes
 type: application
-version: 0.1.0-alpha.13
+version: 0.1.0-alpha.14
 appVersion: "1.0.0"
 
 dependencies:


### PR DESCRIPTION
Bumps the chart version from `0.1.0-alpha.13` to `0.1.0-alpha.14`.