### PR TITLE
feat: gate access:keycloak profiles by a Keycloak role

### DIFF
--- a/config/jupyterhub/00-gateway-auth.py
+++ b/config/jupyterhub/00-gateway-auth.py
@@ -51,6 +51,9 @@ class KCRealmAdmin:
         "component": "shared-directory",
         "scopes": "write:shared-mount",
     }
+    # A jupyterlab-profiles role must carry this component marker for its
+    # ``profiles`` attribute to be honoured: an unmarked role grants nothing.
+    PROFILES_COMPONENT = "jupyterhub-profiles"
 
     def __init__(self, http_fetch, *, token_url, client_id, client_secret, realm_api_url):
         self._http_fetch = http_fetch
@@ -81,7 +84,67 @@ class KCRealmAdmin:
         role_paths = {g.get("path") for g in role_groups if g.get("path")}
         return [g for g in user_groups if g in role_paths]
 
+    async def get_profile_slugs_for_user(self, user_id, role_name):
+        """Return the JupyterLab profile slugs ``user_id`` may select.
+
+        Reads the client role ``role_name``. When that role carries
+        ``component=jupyterhub-profiles``, its ``profiles`` attribute is the
+        slug allow-list. The slugs apply only if the user effectively holds
+        the role (assigned directly or inherited from a group).
+
+        Returns ``[]`` when: the role does not exist, lacks the
+        ``jupyterhub-profiles`` component marker, has no ``profiles``
+        attribute, or the user does not hold it. Raises whatever the HTTP
+        fetcher raises on transport failure; callers handle.
+        """
+        token = await self._client_credentials_token()
+        client_uuid = await self._lookup_client_uuid(token, self._client_id)
+        role = await self._get_client_role_or_none(token, client_uuid, role_name)
+        if role is None or not self._role_has_profiles_component(role):
+            return []
+        slugs = (role.get("attributes") or {}).get("profiles") or []
+        if not slugs:
+            return []
+        if not await self._user_holds_client_role(
+            token, client_uuid, user_id, role_name,
+        ):
+            return []
+        return list(slugs)
+
     # --- internals (each step is one HTTP round-trip) -------------------
+
+    async def _get_client_role_or_none(self, token, client_uuid, role_name):
+        """Role representation, or ``None`` when the role does not exist.
+
+        A missing role is the normal state on deployments that have not
+        created the profiles role yet, so a 404 returns ``None`` instead of
+        raising. No warning spam, no degraded login.
+        """
+        try:
+            return await self._admin_get(
+                token, f"/clients/{client_uuid}/roles/{role_name}",
+            )
+        except HTTPClientError as e:
+            if e.code == 404:
+                return None
+            raise
+
+    async def _user_holds_client_role(self, token, client_uuid, user_id, role_name):
+        """True when ``user_id`` effectively holds ``role_name`` on the
+        client, whether assigned directly or inherited via a group. KC's
+        ``role-mappings/.../composite`` endpoint resolves both."""
+        if not user_id:
+            return False
+        roles = await self._admin_get(
+            token,
+            f"/users/{user_id}/role-mappings/clients/{client_uuid}/composite",
+        )
+        return any(r.get("name") == role_name for r in roles or [])
+
+    @classmethod
+    def _role_has_profiles_component(cls, role):
+        attrs = role.get("attributes", {}) or {}
+        return cls.PROFILES_COMPONENT in (attrs.get("component") or [])
 
     async def _client_credentials_token(self):
         body = urlencode({
@@ -233,6 +296,13 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
     shared_mount_role_name = Unicode(
         "allow-group-directory-creation-role", config=True,
     )
+    # Name of the KC client role whose ``profiles`` attribute lists the
+    # JupyterLab profile slugs a holder may select (``access: keycloak``
+    # profiles). The role lives on the hub client and is created + assigned
+    # to users/groups by the deployer in Keycloak; the chart only reads it.
+    jupyterlab_profiles_role_name = Unicode(
+        "jupyterlab-profiles", config=True,
+    )
 
     async def refresh_user(self, user, handler=None):
         """Run KC's refresh_token grant and persist rotated tokens to auth_state.
@@ -324,6 +394,24 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
                 old_filter = auth_state.get("groups_with_permission_to_mount")
                 if old_filter is not None:
                     new_state["groups_with_permission_to_mount"] = old_filter
+            # Re-resolve the role-granted JupyterLab profiles too, so a
+            # mid-session role grant/revoke takes effect on the next spawn.
+            try:
+                new_state["allowed_jupyterlab_profiles"] = (
+                    await self._realm_admin().get_profile_slugs_for_user(
+                        new_state.get("oauth_user", {}).get("sub"),
+                        self.jupyterlab_profiles_role_name,
+                    )
+                )
+            except Exception:
+                self.log.warning(
+                    "rbac: failed to refresh allowed_jupyterlab_profiles "
+                    "for %s, keeping last known set",
+                    user.name, exc_info=True,
+                )
+                old_profiles = auth_state.get("allowed_jupyterlab_profiles")
+                if old_profiles is not None:
+                    new_state["allowed_jupyterlab_profiles"] = old_profiles
         return {"auth_state": new_state}
 
     async def update_auth_model(self, auth_model):
@@ -362,7 +450,32 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
             )
             filtered = []
         auth_model["auth_state"]["groups_with_permission_to_mount"] = filtered
+        auth_model["auth_state"]["allowed_jupyterlab_profiles"] = (
+            await self._resolve_allowed_profiles(
+                auth_model.get("auth_state", {}).get("oauth_user", {}),
+                auth_model.get("name"),
+            )
+        )
         return auth_model
+
+    async def _resolve_allowed_profiles(self, oauth_user, who):
+        """Resolve the JupyterLab profile slugs the user's
+        ``jupyterlab-profiles`` KC role grants, degrading to ``[]`` on any
+        Admin API failure so login/refresh never breaks. The spawner reads
+        ``auth_state["allowed_jupyterlab_profiles"]`` to gate
+        ``access: keycloak`` profiles by slug."""
+        user_id = (oauth_user or {}).get("sub")
+        try:
+            return await self._realm_admin().get_profile_slugs_for_user(
+                user_id, self.jupyterlab_profiles_role_name,
+            )
+        except Exception:
+            self.log.warning(
+                "rbac: failed to resolve allowed_jupyterlab_profiles for %s, "
+                "granting no keycloak-gated profiles this session",
+                who, exc_info=True,
+            )
+            return []
 
     def _realm_admin(self):
         """Build a :class:`KCRealmAdmin` from the authenticator's current
@@ -388,15 +501,18 @@ def configure(
     admin_groups=None,
     realm_api_url: str = "",
     shared_mount_role_name: str = "allow-group-directory-creation-role",
+    jupyterlab_profiles_role_name: str = "jupyterlab-profiles",
 ):
     """Wire KeyCloakOAuthenticator onto JupyterHub's `c` config object.
 
-    ``realm_api_url`` enables role-gated shared-mount RBAC.
-    Pass the KC Admin API root for the realm
+    ``realm_api_url`` enables the role-gated KC Admin API lookups. Pass the
+    KC Admin API root for the realm
     (e.g. ``https://kc.example/admin/realms/nebari``); leave empty to
-    disable. ``shared_mount_role_name`` is the KC client role whose
-    holders get ``/shared/<group>`` mounts — default matches classic
-    nebari.
+    disable. ``shared_mount_role_name`` is the KC client role whose holders
+    get ``/shared/<group>`` mounts. ``jupyterlab_profiles_role_name`` is the
+    KC client role whose ``profiles`` attribute lists the slugs a holder may
+    select for ``access: keycloak`` profiles. Both default to the classic
+    nebari names.
     """
     kc_config = KeyCloakConfig.build(
         issuer=issuer, post_logout_redirect_uri=external_url,
@@ -406,6 +522,9 @@ def configure(
     c.KeyCloakOAuthenticator.client_secret = client_secret
     c.KeyCloakOAuthenticator.realm_api_url = realm_api_url
     c.KeyCloakOAuthenticator.shared_mount_role_name = shared_mount_role_name
+    c.KeyCloakOAuthenticator.jupyterlab_profiles_role_name = (
+        jupyterlab_profiles_role_name
+    )
     c.KeyCloakOAuthenticator.oauth_callback_url = callback_url
     c.KeyCloakOAuthenticator.authorize_url = kc_config.authorize_url
     c.KeyCloakOAuthenticator.token_url = kc_config.token_url
@@ -525,5 +644,9 @@ else:
             shared_mount_role_name=os.environ.get(
                 "KC_SHARED_MOUNT_ROLE",
                 "allow-group-directory-creation-role",
+            ),
+            jupyterlab_profiles_role_name=os.environ.get(
+                "KC_JUPYTERLAB_PROFILES_ROLE",
+                "jupyterlab-profiles",
             ),
         )

--- a/config/jupyterhub/01-spawner.py
+++ b/config/jupyterhub/01-spawner.py
@@ -214,15 +214,14 @@ def _get_profile_groups(auth_state):
     return result
 
 
-def _get_keycloak_profile_names(auth_state):
-    """Profile display_names allowed via ``access: keycloak``.
+def _get_keycloak_profile_slugs(auth_state):
+    """Profile slugs allowed via ``access: keycloak``.
 
-    Read from the user's ``jupyterlab_profiles`` claim, which a Keycloak
-    attribute mapper stamps into the token from the user's group/user
-    attributes (matches classic Nebari).
+    Read from ``auth_state["allowed_jupyterlab_profiles"]``, which the
+    authenticator resolves at login from the user's ``jupyterlab-profiles``
+    Keycloak role (its ``profiles`` attribute) on the hub client.
     """
-    oauth_user = (auth_state or {}).get("oauth_user") or {}
-    return oauth_user.get("jupyterlab_profiles", []) or []
+    return (auth_state or {}).get("allowed_jupyterlab_profiles", []) or []
 
 
 def _profile_username(auth_state):
@@ -236,19 +235,20 @@ def _profile_username(auth_state):
     return oauth_user.get("preferred_username") or ""
 
 
-def _filter_profiles(profiles, groups, username, keycloak_profile_names=()):
+def _filter_profiles(profiles, groups, username, keycloak_profile_slugs=()):
     """Return the profiles a user may select, stripped of gating-only keys.
 
     Mirrors classic Nebari's ``access:`` semantics on each profile:
       * ``access: all`` (or omitted) — visible to everyone.
       * ``access: yaml`` — visible only if the user is in the profile's
         ``users`` list or shares one of the profile's ``groups``.
-      * ``access: keycloak`` — visible only if the profile's ``display_name``
-        is in the user's ``jupyterlab_profiles`` claim, which a Keycloak
-        attribute mapper stamps into the token from group/user attributes.
+      * ``access: keycloak``: visible only if the profile's ``slug`` is in
+        the allow-list granted by the user's ``jupyterlab-profiles`` Keycloak
+        role (its ``profiles`` attribute), resolved at login by the
+        authenticator and stamped into auth_state.
     """
     group_set = set(groups)
-    profile_name_set = set(keycloak_profile_names)
+    profile_slug_set = set(keycloak_profile_slugs)
     visible = []
     for profile in profiles:
         access = profile.get("access", "all")
@@ -258,7 +258,7 @@ def _filter_profiles(profiles, groups, username, keycloak_profile_names=()):
             if not in_users and not in_groups:
                 continue
         elif access == "keycloak":
-            if profile.get("display_name") not in profile_name_set:
+            if profile.get("slug") not in profile_slug_set:
                 continue
         elif access != "all":
             # Fail closed on an unrecognized access mode: restricted profiles
@@ -287,8 +287,8 @@ async def _render_profile_list(spawner):
     auth_state = await spawner.user.get_auth_state()
     groups = _get_profile_groups(auth_state)
     username = _profile_username(auth_state)
-    keycloak_profile_names = _get_keycloak_profile_names(auth_state)
-    visible = _filter_profiles(_profiles, groups, username, keycloak_profile_names)
+    keycloak_profile_slugs = _get_keycloak_profile_slugs(auth_state)
+    visible = _filter_profiles(_profiles, groups, username, keycloak_profile_slugs)
     log.info(
         "profiles: user %s (groups=%s) sees %d/%d profile(s): %s",
         username, groups, len(visible), len(_profiles),

--- a/tests/unit/test_rbac_jupyterlab_profiles.py
+++ b/tests/unit/test_rbac_jupyterlab_profiles.py
@@ -1,0 +1,366 @@
+"""Tests for resolving JupyterLab profiles from a Keycloak role.
+
+Public contract (chart-side):
+
+  After a user authenticates, ``auth_state["allowed_jupyterlab_profiles"]``
+  lists the profile *slugs* the user may select for ``access: keycloak``
+  profiles. The slugs come from a client role on the hub's KC client:
+
+    * configurable role name (default: ``jupyterlab-profiles``)
+    * the role's ``profiles`` attribute holds the slug allow-list
+    * the role must carry ``component=jupyterhub-profiles`` (a typo'd or
+      unmarked role grants nothing)
+
+  The slugs apply only when the user effectively holds the role, whether
+  it was assigned directly or via a group. The role itself is created and
+  assigned by the deployer in Keycloak; the chart only reads it.
+
+  When the realm-admin path is unavailable (KC down, no permissions,
+  service-account misconfigured), the user STILL logs in; they just see
+  no keycloak-gated profiles. Login MUST NOT fail.
+
+These tests drive the authenticator's public ``update_auth_model`` /
+``refresh_user`` through the JupyterHub contract with the KC Admin API
+mocked at the HTTP boundary (``httpfetch``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import types
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from tornado.httpclient import HTTPClientError, HTTPRequest, HTTPResponse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "config" / "jupyterhub" / "00-gateway-auth.py"
+spec = importlib.util.spec_from_file_location("_gateway_auth_profiles", MODULE_PATH)
+ga = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ga)
+
+
+HUB_CLIENT_ID = "jupyterhub-data-science-pack-nebari-data-science-pack"
+HUB_CLIENT_UUID = "53008075-f97e-4efb-8b8b-03c1d13f054a"
+REALM_API = "https://kc.example.test/admin/realms/nebari"
+TOKEN_URL = "https://kc.example.test/realms/nebari/protocol/openid-connect/token"
+SHARED_MOUNT_ROLE = "allow-group-directory-creation-role"
+PROFILES_ROLE = "jupyterlab-profiles"
+USER_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def _profiles_role_payload(profiles=("gpu", "hpc"), component="jupyterhub-profiles"):
+    """Shape KC's `GET clients/{id}/roles/{name}` returns for the
+    jupyterlab-profiles role carrying a slug allow-list."""
+    attrs = {"profiles": list(profiles)}
+    if component is not None:
+        attrs["component"] = [component]
+    return {
+        "id": "00000000-aaaa-bbbb-cccc-000000000002",
+        "name": PROFILES_ROLE,
+        "composite": False,
+        "clientRole": True,
+        "containerId": HUB_CLIENT_UUID,
+        "attributes": attrs,
+    }
+
+
+def _make_authenticator(**overrides):
+    auth = ga.KeyCloakOAuthenticator()
+    auth.token_url = TOKEN_URL
+    auth.client_id = HUB_CLIENT_ID
+    auth.client_secret = "sek"
+    auth.realm_api_url = REALM_API
+    auth.shared_mount_role_name = SHARED_MOUNT_ROLE
+    for k, v in overrides.items():
+        setattr(auth, k, v)
+    return auth
+
+
+def _http_error(code, body=b""):
+    fake_req = HTTPRequest("https://kc.test")
+    fake_resp = HTTPResponse(fake_req, code, buffer=BytesIO(body))
+    return HTTPClientError(code, f"HTTP {code}", fake_resp)
+
+
+def _dispatch(*, profiles_role=None, user_holds_profiles_role=True):
+    """httpfetch side-effect covering BOTH the shared-mount path (degraded
+    to no mounts) and the jupyterlab-profiles path under test."""
+    role_payload = profiles_role if profiles_role is not None else _profiles_role_payload()
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        if url == TOKEN_URL and method == "POST":
+            return {"access_token": "admin-bearer-xxx", "expires_in": 60}
+        if url.startswith(f"{REALM_API}/clients?clientId="):
+            return [{"id": HUB_CLIENT_UUID, "clientId": HUB_CLIENT_ID}]
+        # shared-mount role: present but assigned to no groups -> no mounts
+        if url == f"{REALM_API}/clients/{HUB_CLIENT_UUID}/roles/{SHARED_MOUNT_ROLE}":
+            return {
+                "id": "shared", "name": SHARED_MOUNT_ROLE, "clientRole": True,
+                "attributes": {
+                    "component": ["shared-directory"],
+                    "scopes": ["write:shared-mount"],
+                },
+            }
+        if url == f"{REALM_API}/clients/{HUB_CLIENT_UUID}/roles/{SHARED_MOUNT_ROLE}/groups":
+            return []
+        # jupyterlab-profiles role
+        if url == f"{REALM_API}/clients/{HUB_CLIENT_UUID}/roles/{PROFILES_ROLE}":
+            if role_payload is _MISSING:
+                raise _http_error(404, b'{"error":"role not found"}')
+            return role_payload
+        # user's effective client roles
+        if url == (
+            f"{REALM_API}/users/{USER_ID}/role-mappings/clients/"
+            f"{HUB_CLIENT_UUID}/composite"
+        ):
+            return [role_payload] if user_holds_profiles_role else []
+        raise AssertionError(f"unexpected httpfetch call: {method} {url}")
+
+    return fetch
+
+
+_MISSING = object()
+
+
+def _auth_model_for(user_groups, sub=USER_ID):
+    return {
+        "name": "alice",
+        "admin": False,
+        "auth_state": {
+            "access_token": "user-at",
+            "refresh_token": "user-rt",
+            "id_token": "user-id",
+            "token_response": {},
+            "oauth_user": {
+                "sub": sub,
+                "preferred_username": "alice",
+                "groups": user_groups,
+            },
+        },
+    }
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Tracer bullet: role profiles attribute -> allowed_jupyterlab_profiles
+# ---------------------------------------------------------------------------
+
+def test_allowed_profiles_is_role_attribute_when_user_holds_role():
+    """User holds the jupyterlab-profiles role; the role's ``profiles``
+    attribute (slugs) becomes auth_state['allowed_jupyterlab_profiles']."""
+    auth = _make_authenticator()
+    auth.httpfetch = AsyncMock(side_effect=_dispatch())
+    am = _auth_model_for(user_groups=["/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["allowed_jupyterlab_profiles"] == ["gpu", "hpc"]
+
+
+def test_allowed_profiles_empty_when_user_does_not_hold_role():
+    """The role exists with a slug list, but the user is not assigned it
+    (directly or via a group): they get no keycloak-gated profiles."""
+    auth = _make_authenticator()
+    auth.httpfetch = AsyncMock(side_effect=_dispatch(user_holds_profiles_role=False))
+    am = _auth_model_for(user_groups=["/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["allowed_jupyterlab_profiles"] == []
+
+
+def test_allowed_profiles_empty_when_role_missing_component_marker():
+    """A role without ``component=jupyterhub-profiles`` is ignored even if
+    it has a ``profiles`` attribute: the marker is required so an unrelated
+    role can't accidentally grant profiles."""
+    auth = _make_authenticator()
+    auth.httpfetch = AsyncMock(side_effect=_dispatch(
+        profiles_role=_profiles_role_payload(component=None),
+    ))
+    am = _auth_model_for(user_groups=["/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["allowed_jupyterlab_profiles"] == []
+
+
+def test_allowed_profiles_empty_when_role_absent():
+    """No jupyterlab-profiles role created yet (404): login still succeeds,
+    the user simply sees no keycloak-gated profiles."""
+    auth = _make_authenticator()
+    auth.httpfetch = AsyncMock(side_effect=_dispatch(profiles_role=_MISSING))
+    am = _auth_model_for(user_groups=["/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["allowed_jupyterlab_profiles"] == []
+    assert out["name"] == "alice"
+
+
+def test_allowed_profiles_empty_when_user_has_no_sub():
+    """Without a KC user id (``sub``) the membership check can't run, so no
+    profiles are granted (fail closed rather than read the role for nobody)."""
+    auth = _make_authenticator()
+    auth.httpfetch = AsyncMock(side_effect=_dispatch())
+    am = _auth_model_for(user_groups=["/data"], sub=None)
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["allowed_jupyterlab_profiles"] == []
+
+
+def test_admin_api_5xx_does_not_break_login():
+    """If the KC Admin API is unreachable / 5xx while resolving profiles,
+    the user must still log in; allowed_jupyterlab_profiles is []."""
+    auth = _make_authenticator()
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        if url == TOKEN_URL:
+            return {"access_token": "admin-bearer-xxx"}
+        raise _http_error(503, b'{"error":"upstream"}')
+
+    auth.httpfetch = AsyncMock(side_effect=fetch)
+    am = _auth_model_for(user_groups=["/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert out["auth_state"]["allowed_jupyterlab_profiles"] == []
+    assert out["name"] == "alice"
+
+
+def test_realm_api_url_empty_skips_profiles_entirely():
+    """RBAC disabled (no realm_api_url): update_auth_model must not call the
+    Admin API and must not set the key; the spawner then shows no
+    keycloak-gated profiles (fail closed)."""
+    auth = _make_authenticator(realm_api_url="")
+    auth.httpfetch = AsyncMock(side_effect=AssertionError(
+        "httpfetch must not be called when realm_api_url is empty"
+    ))
+    am = _auth_model_for(user_groups=["/data"])
+
+    out = _run(auth.update_auth_model(am))
+
+    assert "allowed_jupyterlab_profiles" not in out["auth_state"]
+
+
+# ---------------------------------------------------------------------------
+# refresh_user re-runs the resolution (KC role changes take effect mid-session)
+# ---------------------------------------------------------------------------
+
+class _FakeUser:
+    def __init__(self, name, auth_state):
+        self.name = name
+        self._auth_state = auth_state
+
+    async def get_auth_state(self):
+        return self._auth_state
+
+
+def test_refresh_user_recomputes_allowed_jupyterlab_profiles():
+    """An admin grants the user the jupyterlab-profiles role mid-session.
+    The next refresh_user cycle must re-resolve
+    auth_state['allowed_jupyterlab_profiles'] so the next spawn sees the
+    new profiles (no force-relogin needed)."""
+    auth = _make_authenticator()
+    user = _FakeUser("alice", {
+        "access_token": "old-at",
+        "refresh_token": "old-rt",
+        "id_token": "old-id",
+        "oauth_user": {"sub": USER_ID, "preferred_username": "alice", "groups": ["/data"]},
+    })
+    base = _dispatch()
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        if url == TOKEN_URL and method == "POST" and "refresh_token" in (body or ""):
+            return {
+                "access_token": "new-at",
+                "refresh_token": "new-rt",
+                "id_token": "new-id",
+                "expires_in": 300,
+            }
+        return await base(url, method=method, headers=headers, body=body)
+
+    auth.httpfetch = AsyncMock(side_effect=fetch)
+
+    result = _run(auth.refresh_user(user))
+
+    assert isinstance(result, dict)
+    new_state = result["auth_state"]
+    assert new_state["access_token"] == "new-at", "token rotation still works"
+    assert new_state["allowed_jupyterlab_profiles"] == ["gpu", "hpc"]
+
+
+def test_refresh_user_skips_profiles_when_realm_api_url_empty():
+    """RBAC disabled: refresh_user is a pure token refresh and does not
+    write an allowed_jupyterlab_profiles key."""
+    auth = _make_authenticator(realm_api_url="")
+    user = _FakeUser("alice", {
+        "access_token": "old-at",
+        "refresh_token": "old-rt",
+        "oauth_user": {"sub": USER_ID, "preferred_username": "alice", "groups": ["/data"]},
+    })
+
+    async def fetch(url, method="GET", headers=None, body=None, **kw):
+        assert url == TOKEN_URL and "refresh_token" in (body or ""), (
+            f"realm_api_url empty must mean no Admin API call; got {method} {url}"
+        )
+        return {"access_token": "new-at", "refresh_token": "new-rt"}
+
+    auth.httpfetch = AsyncMock(side_effect=fetch)
+    result = _run(auth.refresh_user(user))
+
+    assert isinstance(result, dict)
+    assert "allowed_jupyterlab_profiles" not in result["auth_state"]
+
+
+# ---------------------------------------------------------------------------
+# configure() wires the role name onto the authenticator
+# ---------------------------------------------------------------------------
+
+def _configure_cfg():
+    return types.SimpleNamespace(
+        JupyterHub=types.SimpleNamespace(),
+        KeyCloakOAuthenticator=types.SimpleNamespace(),
+        Authenticator=types.SimpleNamespace(),
+    )
+
+
+def test_configure_defaults_jupyterlab_profiles_role_name():
+    """Deployers who don't override get the stable default role name."""
+    cfg = _configure_cfg()
+    ga.configure(
+        cfg,
+        issuer="https://kc.example/realms/nebari",
+        client_id="hub-client",
+        client_secret="sek",
+        callback_url="https://hub.example/hub/oauth_callback",
+        external_url="https://hub.example/",
+        realm_api_url="https://kc.example/admin/realms/nebari",
+    )
+    assert cfg.KeyCloakOAuthenticator.jupyterlab_profiles_role_name == (
+        "jupyterlab-profiles"
+    )
+
+
+def test_configure_propagates_custom_jupyterlab_profiles_role_name():
+    """A deployer can rename the role without editing chart code."""
+    cfg = _configure_cfg()
+    ga.configure(
+        cfg,
+        issuer="https://kc.example/realms/nebari",
+        client_id="hub-client",
+        client_secret="sek",
+        callback_url="https://hub.example/hub/oauth_callback",
+        external_url="https://hub.example/",
+        realm_api_url="https://kc.example/admin/realms/nebari",
+        jupyterlab_profiles_role_name="custom-profiles",
+    )
+    assert cfg.KeyCloakOAuthenticator.jupyterlab_profiles_role_name == (
+        "custom-profiles"
+    )

--- a/tests/unit/test_spawner_profiles.py
+++ b/tests/unit/test_spawner_profiles.py
@@ -5,6 +5,9 @@ The data science pack mirrors classic Nebari's ``access:`` semantics on each
 
   * ``access: all`` (or omitted) — every authenticated user sees the profile.
   * ``access: yaml`` — only users in the listed ``groups``/``users`` see it.
+  * ``access: keycloak``: only users whose ``jupyterlab-profiles`` Keycloak
+    role grants the profile's ``slug`` see it (the authenticator resolves the
+    role's ``profiles`` attribute into ``auth_state`` at login).
 
 Gating is applied per user at spawn time by setting
 ``c.KubeSpawner.profile_list`` to an async callable. The callable resolves the
@@ -113,28 +116,41 @@ def test_unknown_access_value_is_hidden():
     assert visible == []
 
 
-def test_keycloak_access_visible_when_display_name_in_profile_attribute():
-    """access: keycloak shows a profile only if its display_name is in the
-    user's ``jupyterlab_profiles`` claim (Keycloak attribute mapper), matching
-    classic Nebari. Gating keys are stripped."""
+def test_keycloak_access_visible_when_slug_in_role_allowlist():
+    """access: keycloak shows a profile only if its ``slug`` is in the
+    allow-list the user's ``jupyterlab-profiles`` Keycloak role grants.
+    Gating keys are stripped."""
     mod, _ = _load()
 
     profiles = [
         {"slug": "gpu", "display_name": "GPU", "access": "keycloak"},
     ]
     visible = mod._filter_profiles(
-        profiles, groups=[], username="alice", keycloak_profile_names=["GPU"]
+        profiles, groups=[], username="alice", keycloak_profile_slugs=["gpu"]
     )
 
     assert visible == [{"slug": "gpu", "display_name": "GPU"}]
 
 
-def test_keycloak_access_hidden_when_display_name_not_in_attribute():
+def test_keycloak_access_hidden_when_slug_not_in_allowlist():
     mod, _ = _load()
 
     profiles = [{"slug": "gpu", "display_name": "GPU", "access": "keycloak"}]
     visible = mod._filter_profiles(
-        profiles, groups=[], username="alice", keycloak_profile_names=["Other"]
+        profiles, groups=[], username="alice", keycloak_profile_slugs=["other"]
+    )
+
+    assert visible == []
+
+
+def test_keycloak_access_matches_slug_not_display_name():
+    """The allow-list is keyed on the stable ``slug``; passing the
+    human-facing ``display_name`` must NOT make the profile visible."""
+    mod, _ = _load()
+
+    profiles = [{"slug": "gpu", "display_name": "GPU", "access": "keycloak"}]
+    visible = mod._filter_profiles(
+        profiles, groups=[], username="alice", keycloak_profile_slugs=["GPU"]
     )
 
     assert visible == []
@@ -159,24 +175,26 @@ def test_get_profile_groups_empty_without_auth_state():
     assert mod._get_profile_groups(None) == []
 
 
-def test_get_keycloak_profile_names_reads_oauth_user_attribute():
-    """The keycloak-mode profile names come from the oauth_user
-    ``jupyterlab_profiles`` claim, matching classic Nebari."""
+def test_get_keycloak_profile_slugs_reads_role_allowlist_from_auth_state():
+    """The keycloak-mode profile slugs come from
+    ``auth_state["allowed_jupyterlab_profiles"]``, which the authenticator
+    resolves from the user's ``jupyterlab-profiles`` Keycloak role."""
     mod, _ = _load()
 
-    auth_state = {"oauth_user": {"jupyterlab_profiles": ["GPU", "High RAM"]}}
-    assert mod._get_keycloak_profile_names(auth_state) == ["GPU", "High RAM"]
+    auth_state = {"allowed_jupyterlab_profiles": ["gpu", "high-ram"]}
+    assert mod._get_keycloak_profile_slugs(auth_state) == ["gpu", "high-ram"]
 
 
-def test_get_keycloak_profile_names_empty_without_attribute():
+def test_get_keycloak_profile_slugs_empty_without_allowlist():
     mod, _ = _load()
 
-    assert mod._get_keycloak_profile_names({"oauth_user": {}}) == []
-    assert mod._get_keycloak_profile_names(None) == []
+    assert mod._get_keycloak_profile_slugs({}) == []
+    assert mod._get_keycloak_profile_slugs(None) == []
 
 
-def test_render_profile_list_applies_keycloak_attribute_gating():
-    """The async callable threads jupyterlab_profiles into keycloak gating."""
+def test_render_profile_list_applies_keycloak_role_gating():
+    """The async callable threads the role-granted slug allow-list
+    (``auth_state["allowed_jupyterlab_profiles"]``) into keycloak gating."""
     mod, _ = _load()
 
     mod._profiles = [
@@ -186,7 +204,8 @@ def test_render_profile_list_applies_keycloak_attribute_gating():
     ]
     auth_state = {
         "groups": [],
-        "oauth_user": {"preferred_username": "alice", "jupyterlab_profiles": ["GPU"]},
+        "allowed_jupyterlab_profiles": ["gpu"],
+        "oauth_user": {"preferred_username": "alice"},
     }
     visible = asyncio.run(mod._render_profile_list(_FakeSpawner(auth_state)))
 

--- a/values.yaml
+++ b/values.yaml
@@ -367,11 +367,14 @@ jupyterhub:
     #                     groups intersect ``groups``, or whose
     #                     preferred_username is in ``users``. A user in none of
     #                     these never sees it.
-    #   access: keycloak  profile is visible only when its ``display_name`` is
-    #                     in the user's ``jupyterlab_profiles`` claim. That
-    #                     claim is populated by a Keycloak attribute mapper
-    #                     from the user's group/user attributes, so the
-    #                     allow-list lives in Keycloak rather than in this file.
+    #   access: keycloak  profile is visible only when its ``slug`` is in the
+    #                     allow-list granted by the user's ``jupyterlab-profiles``
+    #                     Keycloak role. The deployer creates that client role on
+    #                     the hub client, puts the allowed slugs in its
+    #                     ``profiles`` attribute (and ``component=jupyterhub-profiles``),
+    #                     and assigns the role to users or groups. The hub reads
+    #                     it via the KC Admin API at login, so the allow-list
+    #                     lives in Keycloak rather than in this file.
     # Any other access value fails closed (the profile is hidden) so a typo
     # cannot expose an expensive GPU/large-instance profile to everyone.
     # The ``access``/``groups``/``users`` keys are gating-only and are stripped


### PR DESCRIPTION
Gate `access: keycloak` profiles by a Keycloak client role on the hub client instead of a token claim.

The authenticator reads the `jupyterlab-profiles` role (KC Admin API, at login + refresh): when it carries `component=jupyterhub-profiles`, its `profiles` attribute lists the allowed profile slugs, applied only when the user holds the role (directly or via a group). The spawner matches each profile's `slug` against that list. The deployer creates and assigns the role in Keycloak; the chart only reads it. Role name overridable via `KC_JUPYTERLAB_PROFILES_ROLE`.