### PR TITLE
chore: bump nebi image to v0.12 (sha-f4b23ca)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -221,7 +221,7 @@ nebi:
     # Pinned per chart release by CI (scripts/bump_image_tags.py); deployers
     # can override to test a PR build or roll forward. Leave non-empty so
     # the init container is wired by default.
-    tag: "sha-32d0bc9"
+    tag: "sha-f4b23ca"
     pullPolicy: IfNotPresent
   # External Nebi FQDN (browser-side, used for OIDC redirect).
   # If empty, derived from keycloak.hostname as


### PR DESCRIPTION
Point the nebi binary init-container image at the **v0.12** release (commit `f4b23ca`).

- `values.yaml`: `nebi.image.tag` `sha-32d0bc9` -> `sha-f4b23ca`

Note: `sha-f4b23ca` is the image built for the v0.12 commit. Its `/version` reports `0.12-rc3.dev+f4b23ca` because nebi's docker build runs on `main`/PR pushes, not tag pushes, so the build predates the `v0.12` tag.