### PR TITLE
chore: bump chart version to 0.1.0-alpha.15

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nebari-data-science-pack
 description: A Helm chart for deploying JupyterHub with jhub-apps on Kubernetes
 type: application
-version: 0.1.0-alpha.14
+version: 0.1.0-alpha.15
 appVersion: "1.0.0"
 
 dependencies:


### PR DESCRIPTION
Bumps the Helm chart `version` `0.1.0-alpha.14` -> `0.1.0-alpha.15`.

Cuts a chart release for the nebi v0.12 image bump merged in #110 (the image change alone did not touch `Chart.yaml`, so the Release Chart workflow did not fire). On merge, `Release Chart` packages and publishes `nebari-data-science-pack-0.1.0-alpha.15`.