### PR TITLE
Default nebariapp routing to / so the hub is exposed out of the box

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -53,10 +53,13 @@ nebariapp:
     # JupyterHub proxy service (created by jupyterhub subchart)
     name: proxy-public
     port: 80
-  # routing:
-  #   routes:
-  #     - pathPrefix: /
-  #       pathType: Exact
+  # Gateway routing. Defaults to sending all paths to the JupyterHub proxy so
+  # the operator creates the HTTPRoute (and, with it, the TLS listener/cert)
+  # out of the box. Without this the NebariApp reports RoutingNotConfigured and
+  # the hub is never exposed.
+  routing:
+    routes:
+      - pathPrefix: /
   auth:
     enabled: true
     provider: keycloak


### PR DESCRIPTION
The chart shipped `nebariapp.routing` commented out, so a NebariApp rendered from default values had no routing. The operator then reports `RoutingNotConfigured` and creates no HTTPRoute or TLS listener, leaving JupyterHub unreachable over the gateway until routing is supplied by hand.

Defaults it to a single `pathPrefix: /` route (matching nebi-pack), which also lets the operator auto-provision the TLS certificate.