### PR TITLE
Pin jhub-app-proxy to v0.2.3 for pixi/nebi env activation

### DIFF
--- a/config/jupyterhub/02-jhub-apps.py
+++ b/config/jupyterhub/02-jhub-apps.py
@@ -57,6 +57,16 @@ if _nebi_remote and "additional_services" not in japps_config:
         }],
     }
 
+# Pin jhub-app-proxy to a version that supports pixi/nebi env activation.
+# Older proxies (<= v0.2.2) only do conda activation, so apps launched into a
+# Nebi (pixi) environment fail to find their packages. Configurable via
+# jupyterhub.custom.jhub-app-proxy-version (an explicit japps-config entry
+# still wins).
+japps_config.setdefault(
+    "jhub_app_proxy_version",
+    get_config("custom.jhub-app-proxy-version", "v0.2.3"),
+)
+
 for key, value in japps_config.items():
     setattr(c.JAppsConfig, key, value)
 

--- a/values.yaml
+++ b/values.yaml
@@ -337,6 +337,10 @@ jupyterhub:
     # If empty, derived as `<nebi.image.repository>:<nebi.image.tag>`.
     nebi-image: ""
     nebi-image-pull-policy: "IfNotPresent"
+    # jhub-app-proxy version installed at app-spawn time. Must be >= v0.2.3 for
+    # apps to run inside a Nebi (pixi) environment; older versions only support
+    # conda activation and fall back to the base env (missing packages).
+    jhub-app-proxy-version: "v0.2.3"
     # External Nebi URL. If empty, derived from nebi.remoteURL (which
     # itself defaults from keycloak.hostname + subdomains.nebi).
     nebi-remote-url: ""


### PR DESCRIPTION
Apps launched into a Nebi (pixi) environment failed: the default jhub-app-proxy (v0.2.2) only does conda activation, so with no conda in the image it ran the app in the base environment and packages like `streamlit` were missing.

v0.2.3 adds pixi/nebi activation (used when `JHUB_APP_ENV_MANAGER=pixi`, which the spawner already sets). Defaults the proxy version via a new `jupyterhub.custom.jhub-app-proxy-version` value (overridable; an explicit `japps-config.jhub_app_proxy_version` still wins).