### PR TITLE
chore: bump chart version to 0.1.0-alpha.16

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nebari-data-science-pack
 description: A Helm chart for deploying JupyterHub with jhub-apps on Kubernetes
 type: application
-version: 0.1.0-alpha.15
+version: 0.1.0-alpha.16
 appVersion: "1.0.0"
 
 dependencies:


### PR DESCRIPTION
Release the merged routing default (#113) and jhub-app-proxy v0.2.3 pin (#115).