### PR TITLE
docs: GPU profile toleration for tainted EKS nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ make down
 
 See `values.yaml` for all configuration options. The chart wraps the [JupyterHub Helm chart](https://z2jh.jupyter.org/) - all `jupyterhub.*` values are passed through.
 
+- [GPU profiles](docs/gpu-profiles.md) - requesting GPUs and scheduling onto tainted GPU nodes on EKS.
+
 ## Shared Storage
 
 Per-group shared directories (`/shared/<group>` in every user pod) need a

--- a/docs/gpu-profiles.md
+++ b/docs/gpu-profiles.md
@@ -1,0 +1,48 @@
+# GPU Profiles
+
+A profile requests a GPU by setting `extra_resource_limits` in its
+`kubespawner_override`:
+
+```yaml
+jupyterhub:
+  custom:
+    profiles:
+      - slug: gpu-instance
+        display_name: "GPU Instance"
+        kubespawner_override:
+          extra_resource_limits:
+            nvidia.com/gpu: 1
+```
+
+## Scheduling onto tainted GPU nodes (EKS)
+
+On EKS, NIC taints GPU node groups with `nvidia.com/gpu=true:NoSchedule` so
+ordinary pods stay off GPU nodes. EKS cannot run the `ExtendedResourceToleration`
+admission controller (it is not available on the managed control plane), so
+nothing injects the matching toleration for you. Without it, a GPU server stays
+`Pending` and never schedules onto the GPU node.
+
+Add the toleration to the GPU profile's `kubespawner_override`. `kubespawner_override`
+accepts any KubeSpawner trait, and `tolerations` is one of them, so no chart code
+change is needed:
+
+```yaml
+jupyterhub:
+  custom:
+    profiles:
+      - slug: gpu-instance
+        display_name: "GPU Instance"
+        kubespawner_override:
+          extra_resource_limits:
+            nvidia.com/gpu: 1
+          tolerations:
+            - key: "nvidia.com/gpu"
+              operator: "Exists"
+              effect: "NoSchedule"
+```
+
+`operator: Exists` matches the taint regardless of its value, so it works with
+NIC's `value: "true"` and any other value. Non-GPU profiles need no toleration.
+
+> Auto-injecting this toleration for any GPU profile is tracked in
+> [issue #117](https://github.com/nebari-dev/nebari-data-science-pack/issues/117).


### PR DESCRIPTION
NIC taints EKS GPU nodes `nvidia.com/gpu=true:NoSchedule` and EKS has no auto-toleration, so GPU servers stay Pending. Documents adding the toleration to a profile's `kubespawner_override` (already supported, no code change). Workaround for #117.

A follow up for doing this automatically would be to add the toleration when using a GPU image.