### PR TITLE
ci: publish chart to central nebari-dev/helm-repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,3 +77,28 @@ jobs:
           git add .
           git commit -m "Release ${{ steps.chart.outputs.name }}-${{ steps.chart.outputs.version }}"
           git push origin gh-pages --force
+
+      # Stage a clean chart source directory from the packaged tarball.
+      # `helm package` applies .helmignore, so extracting the .tgz yields
+      # _stage/<chart-name>/ without VCS/dev junk. This is what the central
+      # repo's source tree receives, and it matches the artifact we publish
+      # to our own gh-pages above.
+      - name: Stage chart source for central sync
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          mkdir -p _stage
+          tar -xzf *.tgz -C _stage
+
+      # Open a PR in nebari-dev/helm-repository to publish this chart to the
+      # central catalog (gh-pages index + quay.io OCI). On merge, that repo's
+      # Release Helm Charts workflow packages, indexes, and publishes it.
+      # Requires the org secret NEBARI_HELM_REPO_TOKEN to be granted to this
+      # repository (fine-grained PAT with contents+PR write on helm-repository).
+      - name: Sync chart to central helm-repository
+        if: steps.check.outputs.exists == 'false'
+        uses: nebari-dev/helm-repository/.github/actions/sync-chart@577b5a8b7575bb9a97ee06aaca0fcdade4f177bb  # main 2026-06-19
+        with:
+          chart-path: _stage/nebari-data-science-pack
+          chart-name: nebari-data-science-pack
+          token: ${{ secrets.NEBARI_HELM_REPO_TOKEN }}
+          lint-chart: 'false'

--- a/README.md
+++ b/README.md
@@ -16,11 +16,25 @@ A Helm chart for deploying JupyterHub with [jhub-apps](https://github.com/nebari
 
 ### Install from Helm Repository
 
+The chart is published to the central Nebari Helm repository:
+
 ```bash
-helm repo add nebari https://nebari-dev.github.io/nebari-data-science-pack
+helm repo add nebari https://raw.githubusercontent.com/nebari-dev/helm-repository/gh-pages/
 helm repo update
 helm install data-science-pack nebari/nebari-data-science-pack
 ```
+
+It is also available as an OCI artifact on quay.io (no `helm repo add` needed):
+
+```bash
+helm install data-science-pack oci://quay.io/nebari/charts/nebari-data-science-pack --version <version>
+```
+
+> **Cutover note:** releases from `0.1.0-alpha.16` onward publish to the central
+> repository above. The previous per-repo index at
+> `https://nebari-dev.github.io/nebari-data-science-pack` is frozen; releases
+> packaged there before the cutover remain installable from it, but new
+> versions land only in the central repository.
 
 ### Install from Source
 


### PR DESCRIPTION
Closes #130.

On each version release, the release workflow now opens a PR in `nebari-dev/helm-repository` (via its `sync-chart` action), so the chart publishes to the central catalog: the gh-pages index and the `quay.io/nebari/charts` OCI registry. The chart source is staged from the packaged `.tgz` so the central tree gets the same content (minus VCS/dev junk) we already ship to our own gh-pages, which keeps publishing during the transition (dual-publish). README install instructions point at the central repo (`helm repo add` URL + OCI), with a cutover note that pre-cutover alpha releases stay installable from the old per-repo index.

- Requires the org secret `NEBARI_HELM_REPO_TOKEN` (fine-grained PAT, contents+PR write on helm-repository) to be granted to this repo before the sync step can open the PR.